### PR TITLE
draft api docs for blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,82 @@ test.all(common)
 
 A valid (read: that follows this interface) IPFS core implementation, must expose the following API.
 
+## Block
+
+### `block.put`
+
+> Create a new IPFS Block.
+
+##### `Go` **WIP**
+
+##### `JavaScript` - ipfs.block.put(data, [callback])
+
+Where `data` can be a
+
+- Buffer, requiring that the encoding is specified on the options. If no
+  encoding is specified, Buffer is treated as the Data field
+- [Block][] instance
+
+`callback` has the signature `function (err, block) {}`, where `err` is an error
+if the operation was not successful. and `block` is a [Block][].
+
+
+
+
+### `block.get`
+
+> Retrieve an IPFS Block from the underlying Block Store by its mulithash.
+
+##### `Go` **WIP**
+
+##### `JavaScript` - ipfs.block.get(multihash, [callback])
+
+`multihash` is a [multihash][] which can be passed as a
+
+- Buffer, the raw Buffer of the multihash (or of and encoded version)
+- String, the toString version of the multihash (or of an encoded version)
+
+`callback` must follow the signature `function (err, node) {}`, where `err` is
+an error if the operation was not successful and `block` is a [Block][].
+
+If no `callback` is passed, a promise is returned.
+
+
+
+
+### `block.stat`
+
+> Returns various stats of an IPFS Block
+
+##### `Go` **WIP**
+
+##### `JavaScript` - ipfs.block.stat(multihash, [options, callback])
+
+`multihash` is a [multihash][] which can be passed as:
+
+- Buffer, the raw Buffer of the multihash (or of and encoded version)
+- String, the toString version of the multihash (or of an encoded version)
+
+`callback` must follow the signature `function (err, stats) {}`, where `err` is
+an error if the operation was not successful and `stats` is an object with
+the format
+
+```JavaScript
+{
+  Hash: 'QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD',
+  NumLinks: 0,
+  BlockSize: 10,
+  LinksSize: 2,
+  DataSize: 8,
+  CumulativeSize: 10
+}
+```
+
+If no `callback` is passed, a promise is returned.
+
+
+
+
 ## Object
 
 ### `object.new`
@@ -118,10 +194,6 @@ If no `callback` is passed, a promise is returned.
 `callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][]
 
 If no `callback` is passed, a promise is returned.
-
-### `object.data`
-
-> Returns the Data field of an object
 
 ##### `Go` **WIP**
 
@@ -309,5 +381,6 @@ If no `callback` is passed, a promise is returned.
 If no `callback` is passed, a promise is returned.
 
 
+[Block]: https://github.com/ipfs/js-ipfs-block
 [DAGNode]: https://github.com/vijayee/js-ipfs-merkle-dag
 [multihash]: http://github.com/jbenet/multihash

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.get(multihash, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -126,7 +126,7 @@ If no `callback` is passed, a promise is returned.
 ##### `Go` **WIP**
 
 ##### `JavaScript` - ipfs.object.data(multihash, [options, callback])
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -147,7 +147,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.links(multihash, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -172,7 +172,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.stat(multihash, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -212,7 +212,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.patch.addLink(multihash, DAGLink, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -239,7 +239,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.patch.rmLink(multihash, DAGLink, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -266,7 +266,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.patch.appendData(multihash, data, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -293,7 +293,7 @@ If no `callback` is passed, a promise is returned.
 
 ##### `JavaScript` - ipfs.object.patch.setData(multihash, data, [options, callback])
 
-`multihash` is a [multihash]() which can be passed as:
+`multihash` is a [multihash][] which can be passed as:
 
 - Buffer, the raw Buffer of the multihash (or of and encoded version)
 - String, the toString version of the multihash (or of an encoded version)
@@ -310,3 +310,4 @@ If no `callback` is passed, a promise is returned.
 
 
 [DAGNode]: https://github.com/vijayee/js-ipfs-merkle-dag
+[multihash]: http://github.com/jbenet/multihash

--- a/README.md
+++ b/README.md
@@ -116,12 +116,8 @@ the format
 
 ```JavaScript
 {
-  Hash: 'QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD',
-  NumLinks: 0,
-  BlockSize: 10,
-  LinksSize: 2,
-  DataSize: 8,
-  CumulativeSize: 10
+  Key: 'QmPTkMuuL6PD8L2SwTwbcs1NPg14U8mRzerB1ZrrBrkSDD',
+  Size: 10
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A valid (read: that follows this interface) IPFS core implementation, must expos
 
 ##### `JavaScript` - ipfs.object.new([callback])
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js)
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][]
 
 If no `callback` is passed, a promise is returned.
 
@@ -84,13 +84,13 @@ If no `callback` is passed, a promise is returned.
 
 - Object, with format `{ Data: <data>, Links: [] }`
 - Buffer, requiring that the encoding is specified on the options. If no encoding is specified, Buffer is treated as the Data field
-- [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js). 
+- [DAGNode][]
 
 `options` is a optional argument of type object, that can contain the following properties:
 
 - `enc`, the encoding of the Buffer (json, yml, etc), if passed a Buffer.
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js)
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][]
 
 If no `callback` is passed, a promise is returned.
 
@@ -115,7 +115,7 @@ If no `callback` is passed, a promise is returned.
 
 - `enc`, the encoding of multihash (base58, base64, etc), if any.
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js)
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][]
 
 If no `callback` is passed, a promise is returned.
 
@@ -223,7 +223,7 @@ If no `callback` is passed, a promise is returned.
 
 - `enc`, the encoding of multihash (base58, base64, etc), if any.
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js) that resulted by the operation of adding a Link.
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][] that resulted by the operation of adding a Link.
 
 If no `callback` is passed, a promise is returned.
 
@@ -250,7 +250,7 @@ If no `callback` is passed, a promise is returned.
 
 - `enc`, the encoding of multihash (base58, base64, etc), if any.
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js) that resulted by the operation of adding a Link.
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][] that resulted by the operation of adding a Link.
 
 If no `callback` is passed, a promise is returned.
 
@@ -277,7 +277,7 @@ If no `callback` is passed, a promise is returned.
 
 - `enc`, the encoding of multihash (base58, base64, etc), if any.
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js) that resulted by the operation of adding a Link.
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][] that resulted by the operation of adding a Link.
 
 If no `callback` is passed, a promise is returned.
 
@@ -304,6 +304,9 @@ If no `callback` is passed, a promise is returned.
 
 - `enc`, the encoding of multihash (base58, base64, etc), if any.
 
-`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode](https://github.com/vijayee/js-ipfs-merkle-dag/blob/master/src/dag-node.js) that resulted by the operation of adding a Link.
+`callback` must follow `function (err, node) {}` signature, where `err` is an error if the operation was not successful and `node` is a MerkleDAG node of the type [DAGNode][] that resulted by the operation of adding a Link.
 
 If no `callback` is passed, a promise is returned.
+
+
+[DAGNode]: https://github.com/vijayee/js-ipfs-merkle-dag


### PR DESCRIPTION
1. `del` was intentionally omitted. It's not in js-ipfs-api, so let's not commit to it until there's a clear need / demand.
2. js-ipfs-api and js-ipfs core disagree on the return object of `block.stat`. The former is *way* more descriptive than the latter, so we can go with that.