### PR TITLE
Run lint instead of test in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,7 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get --only-upgrade install google-chrome-stable
     - google-chrome --version
+
+test:
+  override:
+    - npm run lint


### PR DESCRIPTION
Instead of running npm test that should fail, lets just print that we have no tests and then exit cleanly

Fixes failing build from here: https://github.com/ipfs/interface-ipfs-core/pull/36