### PR TITLE
fix: ending the test only when we are sure we got the root dir out

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -192,10 +192,9 @@ module.exports = (common) => {
               stream.on('data', (file) => {
                 if (file.path === 'test-folder') {
                   expect(file.hash).to.equal(expectedRootMultihash)
+                  done()
                 }
               })
-
-              stream.on('end', done)
 
               files.forEach((file) => {
                 stream.write(file)


### PR DESCRIPTION
Previously, the test was passing because the end event was being emitted prematurely.