### PR TITLE
Listen on API and Gateway

### DIFF
--- a/src/swarm.js
+++ b/src/swarm.js
@@ -114,8 +114,8 @@ module.exports = (common) => {
           return {
             Addresses: {
               Swarm: addresses,
-              API: null,
-              Gateway: null
+              API: '/ip4/127.0.0.1/tcp/0',
+              Gateway: '/ip4/127.0.0.1/tcp/0'
             }
           }
         }


### PR DESCRIPTION
The reason for this is that js-ipfs expects these to be multiaddrs, when
my expectation was that these could be null and therefore disable the
functionality