### PR TITLE
fixes example should get the whole tree

### DIFF
--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -148,7 +148,7 @@ function errOrLog(err, result) {
   if (err) {
     console.error('error: ' + err)
   } else {
-    console.log(result.value)
+    console.log(result)
   }
 }
 

--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -152,7 +152,7 @@ function errOrLog(err, result) {
   }
 }
 
-ipfs.dag.tree('zdpuAmtur968yprkhG9N5Zxn6MFVoqAWBbhUAkNLJs2UtkTq5/a', errOrLog)
+ipfs.dag.tree('zdpuAmtur968yprkhG9N5Zxn6MFVoqAWBbhUAkNLJs2UtkTq5', errOrLog)
 // Logs:
 // a
 // b


### PR DESCRIPTION
JavaScript implementation would only log the tree for 'a' which would log []

Pretty sure this is an example bug