### PR TITLE
fix: swarm connect to local servers

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -201,9 +201,9 @@ module.exports = (common) => {
     describe('multiple nodes connected', () => {
       before((done) => {
         parallel([
-          (cb) => ipfs1.swarm.connect(ipfs2.peerId.addresses[0], cb),
-          (cb) => ipfs2.swarm.connect(ipfs3.peerId.addresses[0], cb),
-          (cb) => ipfs1.swarm.connect(ipfs3.peerId.addresses[0], cb)
+          (cb) => ipfs1.swarm.connect(ipfs2.peerId.addresses.find(a => a.includes('127.0.0.1')), cb),
+          (cb) => ipfs2.swarm.connect(ipfs3.peerId.addresses.find(a => a.includes('127.0.0.1')), cb),
+          (cb) => ipfs1.swarm.connect(ipfs3.peerId.addresses.find(a => a.includes('127.0.0.1')), cb)
         ], (err) => {
           if (err) {
             return done(err)


### PR DESCRIPTION
Prevent dialer timeouts and speed up the tests.

This gets all the pubsub tests working!

> aegir test -t node --timeout 5000 -f test\interface\pubsub.spec.js
```
Test Node.js


  .pubsub
Secp256k1 bindings are not compiled. Pure JS implementation will be used.
Secp256k1 bindings are not compiled. Pure JS implementation will be used.
    single node
      .publish
        √ errors on string messags
        √ message from buffer
      .subscribe
        √ to one topic
        √ attaches multiple event listeners
        √ discover options
    multiple nodes connected
      .peers
        √ does not error when not subscribed to a topic
        √ doesn't return extra peers
        √ returns peers for a topic - one peer (529ms)
        √ lists peers for a topic - multiple peers (526ms)
      .ls
        √ empty() list when no topics are subscribed
        √ list with 1 subscribed topic
        √ list with 3 subscribed topics
      multiple nodes
        √ receive messages from different node (526ms)
        √ round trips a non-utf8 binary buffer correctly (529ms)
        √ receive multiple messages (540ms)
      load tests
        √ call publish 1k times (3447ms)
Send/Receive 10k messages took: 34059 ms, 293 ops / s

        √ send/receive 10k messages (34575ms)
        √ call subscribe/unsubscribe 1k times (46ms)


  18 passing (1m)
````