### PR TITLE
doc: modify javascripte usage link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   - [Badge](#badge)
 - [Install](#install)
 - [Usage](#usage)
-  - [JavaScript](#nodejs)
+  - [JavaScript](#javascript)
   - [Go](#go)
 - [API](#api)
 - [Contribute](#contribute)


### PR DESCRIPTION
Because the link of javascript usage was wrong, it is correct to be changed to #javascript.