### PR TITLE
fix: cat not found message in go-ipfs

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -436,7 +436,9 @@ module.exports = (common) => {
         return ipfs.files.cat(smallFile.cid + '/does-not-exist')
           .catch((err) => {
             expect(err).to.exist()
-            expect(err.message).to.contain('No such file')
+            expect(err.message).to.oneOf([
+              'No such file',
+              'no link named "does-not-exist" under Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'])
           })
       })
 


### PR DESCRIPTION
For js-ipfs-api tests to run.