### PR TITLE
Fixes dns test with callback

### DIFF
--- a/src/miscellaneous.js
+++ b/src/miscellaneous.js
@@ -50,10 +50,11 @@ module.exports = (common) => {
       })
     })
 
-    it('.dns', () => {
-      return ipfs.dns('ipfs.io', (err, path) => {
+    it('.dns', (done) => {
+      ipfs.dns('ipfs.io', (err, path) => {
         expect(err).to.not.exist()
         expect(path).to.exist()
+        done()
       })
     })
 


### PR DESCRIPTION
Test was previously passing because mocha didn't know it was async and no assertions were made