### PR TITLE
Update PUBSUB.md

### DIFF
--- a/SPEC/PUBSUB.md
+++ b/SPEC/PUBSUB.md
@@ -101,9 +101,8 @@ A great source of [examples][] can be found in the tests for this API.
 
 ##### `Go` **WIP**
 
-##### `JavaScript` - ipfs.pubsub.ls(topic, callback)
+##### `JavaScript` - ipfs.pubsub.ls(callback)
 
-- `topic: string`
 - `callback: (Error, Array<string>>) => ()` - Calls back with an error or a list of topicCIDs that this peer is subscribed to.
 
 If no `callback` is passed, a promise is returned.


### PR DESCRIPTION
The documentation for `pubsub.ls` is wrong here, although the example is accurate. `ls` takes no arguments except for an optional callback; I think the erroneous `topic` argument was copied from the `pubsub.peers` documentation.