### PR TITLE
Link stats.repo and stats.bitswap

### DIFF
--- a/SPEC/BITSWAP.md
+++ b/SPEC/BITSWAP.md
@@ -13,6 +13,8 @@ Bitswap API
 
 ##### `JavaScript` - ipfs.bitswap.stat([callback])
 
+`stats.bitswap` and `bitswap.stat` can be used interchangeably.
+
 `callback` must follow `function (err, stats) {}` signature, where `err` is an error if the operation was not successful. `stats` is an Object containing the following keys:
 
 - `provideBufLen`

--- a/SPEC/BITSWAP.md
+++ b/SPEC/BITSWAP.md
@@ -1,2 +1,47 @@
-bitswap API (not spec'ed yet)
-=============================
+Bitswap API
+=======
+
+#### `wantlist` (not spec'ed yet)
+
+#### `unwant` (not spec'ed yet)
+
+#### `stat`
+
+> Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
+
+##### `Go` **WIP**
+
+##### `JavaScript` - ipfs.bitswap.stat([callback])
+
+`callback` must follow `function (err, stats) {}` signature, where `err` is an error if the operation was not successful. `stats` is an Object containing the following keys:
+
+- `provideBufLen`
+- `wantlist` (array)
+- `peers` (array)
+- `blocksReceived`
+- `dataReceived`
+- `blocksSent`
+- `dataSent`
+- `dupBlksReceived`
+- `dupDataReceived`
+
+If no `callback` is passed, a promise is returned.
+
+**Example:**
+
+```JavaScript
+ipfs.stats.bitswap((err, stats) => console.log(stats))
+
+// { provideBufLen: 0,
+//   wantlist: null,
+//   peers:
+//    [ 'QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
+//      'QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
+//      'QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd' ],
+//   blocksReceived: 0,
+//   dataReceived: 0,
+//   blocksSent: 0,
+//   dataSent: 0,
+//   dupBlksReceived: 0,
+//  dupDataReceived: 0 }
+```

--- a/SPEC/REPO.md
+++ b/SPEC/REPO.md
@@ -33,6 +33,8 @@ ipfs.repo.gc((err, res) => console.log(res))
 
 ##### `JavaScript` - ipfs.repo.stat([options, callback])
 
+`stats.repo` and `repo.stat` can be used interchangeably.
+
 Where:
 
 - `options` is an object that contains following properties

--- a/SPEC/STATS.md
+++ b/SPEC/STATS.md
@@ -3,44 +3,11 @@ Stats API
 
 #### `bitswap`
 
-> Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
+`stats.bitswap` and `bitswap.stat` can be used interchangeably. See [`bitswap.stat`](./BITSWAP.md#stat) for more details.
 
-##### `Go` **WIP**
+#### `repo`
 
-##### `JavaScript` - ipfs.stats.bitswap([callback])
-
-`callback` must follow `function (err, stats) {}` signature, where `err` is an error if the operation was not successful. `stats` is an Object containing the following keys:
-
-- `provideBufLen`
-- `wantlist` (array)
-- `peers` (array)
-- `blocksReceived`
-- `dataReceived`
-- `blocksSent`
-- `dataSent`
-- `dupBlksReceived`
-- `dupDataReceived`
-
-If no `callback` is passed, a promise is returned.
-
-**Example:**
-
-```JavaScript
-ipfs.stats.bitswap((err, stats) => console.log(stats))
-
-// { provideBufLen: 0,
-//   wantlist: null,
-//   peers:
-//    [ 'QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-//      'QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu',
-//      'QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd' ],
-//   blocksReceived: 0,
-//   dataReceived: 0,
-//   blocksSent: 0,
-//   dataSent: 0,
-//   dupBlksReceived: 0,
-//  dupDataReceived: 0 }
-```
+`stats.repo` and `repo.stat` can be used interchangeably. See [`repo.stat`](./REPO.md#stat) for more details.
 
 #### `bw`
 
@@ -76,39 +43,4 @@ ipfs.stats.bw((err, stats) => console.log(stats))
 //   totalOut: 15420,
 //   rateIn: 905.0873512246716,
 //   rateOut: 893.7400053359125 }
-```
-
-#### `stat`
-
-> Get stats for the currently used repo.
-
-##### `Go` **WIP**
-
-##### `JavaScript` - ipfs.repo.stat([options, callback])
-
-Where:
-
-- `options` is an object that contains following properties
-  - `human` a Boolean value to output `repoSize` in MiB.
-
-`callback` must follow `function (err, stats) {}` signature, where `err` is an Error if the operation was not successful and `stats` is an object containing the following keys:
-
-- `numObjects`
-- `repoSize`
-- `repoPath`
-- `version`
-- `storageMax`
-
-If no `callback` is passed, a promise is returned.
-
-**Example:**
-
-```JavaScript
-ipfs.repo.stat((err, stats) => console.log(stats))
-
-// { numObjects: 15,
-//   repoSize: 64190,
-//   repoPath: 'C:\\Users\\henri\\AppData\\Local\\Temp\\ipfs_687c6eb3da07d3b16fe3c63ce17560e9',
-//   version: 'fs-repo@6',
-//   storageMax: 10000000000 }
 ```


### PR DESCRIPTION
`stats.repo` is the same as `repo.stat` and the same happens for `stats.bitswap` and `bitswap.stat`. The goal is to remove the repeated documentation.

@diasdavid take a look 😄