### PR TITLE
Adds missing docs for dht.provide

### DIFF
--- a/SPEC/DHT.md
+++ b/SPEC/DHT.md
@@ -71,6 +71,28 @@ ipfs.dht.get(key, function (err, value) {})
 
 A great source of [examples][] can be found in the tests for this API.
 
+#### `provide`
+
+> Announce to the network that you are providing given values.
+
+##### `Go` **WIP**
+
+##### `JavaScript` - ipfs.dht.provide(cid, [callback])
+
+Where `cid` is a CID or array of CIDs.
+
+`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful.
+
+If no `callback` is passed, a promise is returned.
+
+**Example:**
+
+```JavaScript
+ipfs.dht.provide(cid, function (err) {})
+```
+
+A great source of [examples][] can be found in the tests for this API.
+
 #### `put`
 
 > Store a value on the DHT

--- a/js/src/dht.js
+++ b/js/src/dht.js
@@ -118,21 +118,37 @@ module.exports = (common) => {
 
     describe('.provide', () => {
       it('regular', (done) => {
-        // TODO recheck this test, should it provide or not if block is not available? go-ipfs does provide.
+        nodeC.files.add(Buffer.from('test'), (err, res) => {
+          if (err) return done(err)
+
+          nodeC.dht.provide(new CID(res[0].hash), (err) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+
+      it('should not provide if block not found locally', (done) => {
         const cid = new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ')
 
-        nodeC.dht.provide(cid, done)
+        nodeC.dht.provide(cid, (err) => {
+          expect(err).to.exist()
+          expect(err.message).to.include('not found locally')
+          done()
+        })
       })
 
       it('allows multiple CIDs to be passed', (done) => {
-        const cids = [
-          new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ'),
-          new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxxx')
-        ]
+        nodeC.files.add([Buffer.from('t0'), Buffer.from('t1')], (err, res) => {
+          if (err) return done(err)
 
-        nodeC.dht.provide(cids, (err) => {
-          expect(err).to.not.exist()
-          done()
+          nodeC.dht.provide([
+            new CID(res[0].hash),
+            new CID(res[1].hash)
+          ], (err) => {
+            expect(err).to.not.exist()
+            done()
+          })
         })
       })
 

--- a/js/src/dht.js
+++ b/js/src/dht.js
@@ -124,6 +124,32 @@ module.exports = (common) => {
         nodeC.dht.provide(cid, done)
       })
 
+      it('allows multiple CIDs to be passed', (done) => {
+        const cids = [
+          new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ'),
+          new CID('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxxx')
+        ]
+
+        nodeC.dht.provide(cids, (err) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+
+      it('errors on non CID arg', (done) => {
+        nodeC.dht.provide({}, (err) => {
+          expect(err).to.exist()
+          done()
+        })
+      })
+
+      it('errors on array containing non CID arg', (done) => {
+        nodeC.dht.provide([{}], (err) => {
+          expect(err).to.exist()
+          done()
+        })
+      })
+
       it.skip('recursive', () => {})
     })
 

--- a/js/src/dht.js
+++ b/js/src/dht.js
@@ -152,6 +152,19 @@ module.exports = (common) => {
         })
       })
 
+      it('should provide a CIDv1', (done) => {
+        nodeC.files.add(Buffer.from('test'), { 'cid-version': 1 }, (err, res) => {
+          if (err) return done(err)
+
+          const cid = new CID(res[0].hash)
+
+          nodeC.dht.provide(cid, (err) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+
       it('errors on non CID arg', (done) => {
         nodeC.dht.provide({}, (err) => {
           expect(err).to.exist()


### PR DESCRIPTION
As far as I can tell from the [tests](https://github.com/ipfs/interface-ipfs-core/blob/f5f73070c37f374e0516185b8241622d514d09ae/js/src/dht.js#L124) and [`js-ipfs`](https://github.com/ipfs/js-ipfs/blob/e4d2a15143431a9af37a275a149621738c91aa00/src/core/components/dht.js#L119) (follows through to [`js-ipfs-repo`](https://github.com/ipfs/js-ipfs-repo/blob/c30a7f170a631cc6298c06340bd92321b6fe1cd7/src/blockstore.js#L136) `.has` which expects a CID) it just takes a CID. `js-ipfs` implementation also suggests it can [take an array](https://github.com/ipfs/js-ipfs/blob/e4d2a15143431a9af37a275a149621738c91aa00/src/core/components/dht.js#L109).