### PR TITLE
docs: Fix paths to examples

### DIFF
--- a/SPEC/BLOCK.md
+++ b/SPEC/BLOCK.md
@@ -155,4 +155,4 @@ A great source of [examples][] can be found in the tests for this API.
 
 [block]:https://github.com/ipfs/js-ipfs-block
 [multihash]:https://github.com/multiformats/multihash
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/block.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/block.js

--- a/SPEC/CONFIG.md
+++ b/SPEC/CONFIG.md
@@ -89,4 +89,4 @@ ipfs.config.replace(newConfig, (err) => {
 A great source of [examples][] can be found in the tests for this API.
 
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/config.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/config.js

--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -170,4 +170,4 @@ ipfs.dag.tree('zdpuAmtur968yprkhG9N5Zxn6MFVoqAWBbhUAkNLJs2UtkTq5', errOrLog)
 A great source of [examples][] can be found in the tests for this API.
 
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/dag.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/dag.js

--- a/SPEC/DHT.md
+++ b/SPEC/DHT.md
@@ -118,4 +118,4 @@ ipfs.dht.query(id, function (err, peerInfos) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/dht.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/dht.js

--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -831,7 +831,7 @@ ipfs.files.ls('/screenshots', function (err, files) {
 // 2018-01-22T18:08:49.184Z.png
 ```
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/files.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/files.js
 [b]: https://www.npmjs.com/package/buffer
 [rs]: https://www.npmjs.com/package/readable-stream
 [ps]: https://www.npmjs.com/package/pull-stream

--- a/SPEC/MISCELLANEOUS.md
+++ b/SPEC/MISCELLANEOUS.md
@@ -76,7 +76,7 @@ ipfs.dns('ipfs.io', (err, path) => {
 
 A great source of [examples][] can be found in the tests for this API.
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/miscellaneous.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/miscellaneous.js
 
 #### `stop`
 
@@ -101,4 +101,4 @@ ipfs.stop((err) => {
 
 A great source of [examples][] can be found in the tests for this API.
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/miscellaneous.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/miscellaneous.js

--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -417,4 +417,4 @@ A great source of [examples][] can be found in the tests for this API.
 [DAGNode]: https://github.com/ipld/js-ipld-dag-pb
 [multihash]: http://github.com/multiformats/multihash
 [promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/object.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/object.js

--- a/SPEC/PIN.md
+++ b/SPEC/PIN.md
@@ -92,4 +92,4 @@ ipfs.pin.rm(hash, function (err, pinset) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/pin.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/pin.js

--- a/SPEC/PUBSUB.md
+++ b/SPEC/PUBSUB.md
@@ -146,4 +146,4 @@ ipfs.pubsub.peers(topic, (err, peerIds) => {
 
 A great source of [examples][] can be found in the tests for this API.
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/pubsub.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/pubsub.js

--- a/SPEC/SWARM.md
+++ b/SPEC/SWARM.md
@@ -173,4 +173,4 @@ Example:
 ipfs.swarm.filters.rm(filter, function (err) {})
 ```
 
-[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/src/swarm.js
+[examples]: https://github.com/ipfs/interface-ipfs-core/blob/master/js/src/swarm.js


### PR DESCRIPTION
All links to examples are broken, this PR updates them to point to the right places.