### PR TITLE
fix: adapt dag tests to current environment

### DIFF
--- a/js/src/dag.js
+++ b/js/src/dag.js
@@ -255,7 +255,7 @@ module.exports = (common) => {
           }
           ipfs.dag.get(cidPb, 'Data', (err, result) => {
             expect(err).to.not.exist()
-            expect(result.value.data).to.eql(Buffer.from('I am inside a Protobuf'))
+            expect(result.value).to.eql(Buffer.from('I am inside a Protobuf'))
             done()
           })
         })

--- a/js/src/dag.js
+++ b/js/src/dag.js
@@ -337,18 +337,17 @@ module.exports = (common) => {
       })
     })
 
-    describe.skip('.tree', function () {
-      // TODO vmx 2018-02-22: Currently the tree API is not exposed in go-ipfs
-      if (withGo) {
-        this.skip()
-      }
-
+    describe('.tree', function () {
       let nodePb
       let nodeCbor
       let cidPb
       let cidCbor
 
-      before((done) => {
+      before(function (done) {
+        // TODO vmx 2018-02-22: Currently the tree API is not exposed in go-ipfs
+        if (withGo) {
+          this.skip()
+        }
         series([
           (cb) => {
             dagPB.DAGNode.create(Buffer.from('I am inside a Protobuf'), (err, node) => {

--- a/js/src/dag.js
+++ b/js/src/dag.js
@@ -94,10 +94,13 @@ module.exports = (common) => {
         }, done)
       })
 
-      // This works because dag-pb will serialize any object. If the object
-      // has neither a `data` nor `links` field it's serialized as an empty
-      // object
-      it.skip('dag-cbor node with wrong multicodec', (done) => {
+      it('dag-cbor node with wrong multicodec', function (done) {
+        // This works in go-ipfs because dag-pb will serialize any object. If
+        // the object has neither a `data` nor `links` field it's serialized
+        // as an empty object
+        if (withGo) {
+          this.skip()
+        }
         ipfs.dag.put(cborNode, {
           format: 'dag-pb',
           hashAlg: 'sha3-512'
@@ -252,7 +255,6 @@ module.exports = (common) => {
           }
           ipfs.dag.get(cidPb, 'Data', (err, result) => {
             expect(err).to.not.exist()
-            console.log('vmx: result', result.value)
             expect(result.value.data).to.eql(Buffer.from('I am inside a Protobuf'))
             done()
           })


### PR DESCRIPTION
The current go-ipfs doesn't yet support running all those tests,
but at least part of them. Fix the tests that work and skip the
ones that are not yet supported.