### PR TITLE
complete files.stat with the 'with-local' option

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -618,6 +618,7 @@ Where:
 - `options` is an optional Object that might contain the following keys:
   - `hash` is a Boolean value to return only the hash.
   - `size` is a Boolean value to return only the size.
+  - `withLocal` is a Boolean value to compute the amount of the dag that is local, and if possible the total size.
 
 `callback` must follow the `function (err, stat) {}` signature, where `err` is an Error if the operation was not successful and `stat` is an Object with the following keys:
 
@@ -626,6 +627,10 @@ Where:
 - `cumulativeSize` is an integer with the cumulative size in Bytes.
 - `blocks` is an integer indicating the number of blocks.
 - `type` is a string that can be either `directory` or `file`.
+- `withLocality` is a boolean to indicate if locality information are present.
+- `local` is a boolean to indicate if the queried dag is fully present locally.
+- `sizeLocal` is an integer indicating the cumulative size of the data present locally.
+
 
 If no `callback` is passed, a promise is returned.
 

--- a/js/src/files-mfs.js
+++ b/js/src/files-mfs.js
@@ -276,7 +276,10 @@ module.exports = (common) => {
             blocks: 1,
             size: 13,
             hash: 'QmcZojhwragQr5qhTeFAmELik623Z21e3jBTpJXoQ9si1T',
-            cumulativeSize: 71
+            cumulativeSize: 71,
+            withLocality: false,
+            local: undefined,
+            sizeLocal: undefined
           })
           done()
         })
@@ -295,7 +298,54 @@ module.exports = (common) => {
             blocks: 2,
             size: 0,
             hash: 'QmVrkkNurBCeJvPRohW5JTvJG4AxGrFg7FnmsZZUS6nJto',
-            cumulativeSize: 216
+            cumulativeSize: 216,
+            withLocality: false,
+            local: undefined,
+            sizeLocal: undefined
+          })
+          done()
+        })
+      })
+
+      it('stat withLocal file', function (done) {
+        if (!withGo) {
+          console.log('Not supported in js-ipfs yet')
+          this.skip()
+        }
+
+        ipfs.files.stat('/test/b', {'withLocal': true}, (err, stat) => {
+          expect(err).to.not.exist()
+          expect(stat).to.eql({
+            type: 'file',
+            blocks: 1,
+            size: 13,
+            hash: 'QmcZojhwragQr5qhTeFAmELik623Z21e3jBTpJXoQ9si1T',
+            cumulativeSize: 71,
+            withLocality: true,
+            local: true,
+            sizeLocal: 71
+          })
+          done()
+        })
+      })
+
+      it('stat withLocal dir', function (done) {
+        if (!withGo) {
+          console.log('Not supported in js-ipfs yet')
+          this.skip()
+        }
+
+        ipfs.files.stat('/test', {'withLocal': true}, (err, stat) => {
+          expect(err).to.not.exist()
+          expect(stat).to.eql({
+            type: 'directory',
+            blocks: 2,
+            size: 0,
+            hash: 'QmVrkkNurBCeJvPRohW5JTvJG4AxGrFg7FnmsZZUS6nJto',
+            cumulativeSize: 216,
+            withLocality: true,
+            local: true,
+            sizeLocal: 216
           })
           done()
         })

--- a/js/src/files.js
+++ b/js/src/files.js
@@ -24,6 +24,7 @@ module.exports = (common) => {
     this.timeout(40 * 1000)
 
     let ipfs
+    let withGo
 
     function fixture (path) {
       return loadFixture(path, 'interface-ipfs-core')
@@ -60,7 +61,11 @@ module.exports = (common) => {
         factory.spawnNode((err, node) => {
           expect(err).to.not.exist()
           ipfs = node
-          done()
+          node.id((err, id) => {
+            expect(err).to.not.exist()
+            withGo = id.agentVersion.startsWith('go-ipfs')
+            done()
+          })
         })
       })
     })
@@ -978,6 +983,32 @@ module.exports = (common) => {
             done()
           })
         )
+      })
+    })
+
+    describe('.stat', () => {
+      before((done) => ipfs.files.add(smallFile.data, done))
+
+      it('stat outside of mfs', function (done) {
+        if (!withGo) {
+          console.log('Not supported in js-ipfs yet')
+          this.skip()
+        }
+
+        ipfs.files.stat('/ipfs/' + smallFile.cid, (err, stat) => {
+          expect(err).to.not.exist()
+          expect(stat).to.eql({
+            type: 'file',
+            blocks: 0,
+            size: 12,
+            hash: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
+            cumulativeSize: 20,
+            withLocality: false,
+            local: undefined,
+            sizeLocal: undefined
+          })
+          done()
+        })
       })
     })
   })


### PR DESCRIPTION
Following https://github.com/ipfs/go-ipfs/pull/4638, this new option is present in go-ipfs that enable to know if and how much of a dag is present locally.

Now, in the go-ipfs's http API, `WithLocality`, `Local` and `SizeLocal` in the answer are not present when `with-local` is not active. I chose to set default values in the javascript object response, but it could also be done the same way with no values present at all. Which would be best ?