### PR TITLE
fix: docs and adds test assertion that peer is a PeerId in return value from swarm.peers

### DIFF
--- a/SPEC/SWARM.md
+++ b/SPEC/SWARM.md
@@ -88,7 +88,7 @@ If `opts.verbose` is set to `true` additional information, such as `latency` is 
 `callback` must follow `function (err, peerInfos) {}` signature, where `err` is an error if the operation was not successful. `peerInfos` will be an array of the form
 
 - `addr: Multiaddr`
-- `peer: [PeerInfo]()`
+- `peer: PeerId`
 - `latency: String` Only if `verbose: true`  was passed
 
 Starting with `go-ipfs 0.4.5` these additional properties are provided

--- a/js/src/swarm.js
+++ b/js/src/swarm.js
@@ -9,6 +9,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const series = require('async/series')
 const multiaddr = require('multiaddr')
+const PeerId = require('peer-id')
 const os = require('os')
 const path = require('path')
 const hat = require('hat')
@@ -79,6 +80,7 @@ module.exports = (common) => {
             expect(peer).to.have.a.property('addr')
             expect(multiaddr.isMultiaddr(peer.addr)).to.equal(true)
             expect(peer).to.have.a.property('peer')
+            expect(PeerId.isPeerId(peer.peer)).to.equal(true)
             expect(peer).to.not.have.a.property('latency')
 
             // only available in 0.4.5


### PR DESCRIPTION
As per discussion in https://github.com/ipfs/js-ipfs/issues/1248