### PR TITLE
fix: fix broken stats test

### DIFF
--- a/js/src/files.js
+++ b/js/src/files.js
@@ -919,8 +919,8 @@ module.exports = (common) => {
       })
     })
 
-    describe('.lsPullStream', function (done) {
-      before((done) => {
+    describe('.lsPullStream', () => {
+      before(function (done) {
         // TODO: https://github.com/ipfs/js-ipfs-api/issues/339
         if (!isNode) { this.skip() }
 

--- a/js/src/stats.js
+++ b/js/src/stats.js
@@ -63,7 +63,7 @@ module.exports = (common) => {
       })
     })
 
-    it('.bw Promise', function (done) {
+    it('.bw Promise', function () {
       if (!withGo) {
         console.log('Not supported in js-ipfs yet')
         this.skip()


### PR DESCRIPTION
One test broke due to c4934ca0b3b43f5bfc1ff5dd38f85d945d3244de [1].

If promises are used, you needn't pass `done` as parameter of
the callback in.

[1]: https://github.com/ipfs/interface-ipfs-core/commit/c4934ca0b3b43f5bfc1ff5dd38f85d945d3244de#diff-0a6449ecfa8b9e3d807f53dde24eca71R66