### PR TITLE
Update with example outputting the content to stdout

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -323,14 +323,19 @@ It returns a [Readable Stream][rs] in [Object mode](https://nodejs.org/api/strea
 **Example:**
 
 ```JavaScript
-const validCID = 'QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF'
+const validCID = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
 
 const stream = ipfs.files.getReadableStream(validCID)
 
 stream.on('data', (file) => {
   // write the file's path and contents to standard out
   console.log(file.path)
-  console.log(file.path.toString())
+  if(file.type !== 'dir') {
+    file.content.on('data', (data) => {
+      console.log(data.toString())
+    })
+    file.content.resume()
+  }
 })
 ```
 


### PR DESCRIPTION
I am updating with a example that does what the comment says `write the file's path and contents to standard out`. It takes the getting started docs and outputs them to the console.

https://ipfs.io/docs/getting-started/

https://jsbin.com/niwadeceze/1/edit?js,output

Closing https://github.com/ipfs/interface-ipfs-core/issues/226