### PR TITLE
Js ipfs issue 1145

### DIFF
--- a/js/src/files.js
+++ b/js/src/files.js
@@ -441,10 +441,29 @@ module.exports = (common) => {
         return ipfs.files.cat(smallFile.cid + '/does-not-exist')
           .catch((err) => {
             expect(err).to.exist()
-            expect(err.message).to.contain.oneOf([
-              'No such file',
+            expect(err.message).to.contain(
               'no link named "does-not-exist" under Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
-            ])
+            )
+          })
+      })
+
+      it('specifies missing directory in a nested link', () => {
+        return ipfs.files.cat(directory.cid + '/files/missing-dir/does-not-exist')
+          .catch((err) => {
+            expect(err).to.exist()
+            expect(err.message).to.contain(
+              'no link named "missing-dir" under QmZ25UfTqXGz9RsEJFg7HUAuBcmfx5dQZDXQd2QEZ8Kj74'
+            )
+          })
+      })
+
+      it('specifies missing file in a nested link', () => {
+        return ipfs.files.cat(directory.cid + '/files/does-not-exist')
+          .catch((err) => {
+            expect(err).to.exist()
+            expect(err.message).to.contain(
+              'no link named "does-not-exist" under QmZ25UfTqXGz9RsEJFg7HUAuBcmfx5dQZDXQd2QEZ8Kj74'
+            )
           })
       })
 

--- a/js/src/files.js
+++ b/js/src/files.js
@@ -441,9 +441,10 @@ module.exports = (common) => {
         return ipfs.files.cat(smallFile.cid + '/does-not-exist')
           .catch((err) => {
             expect(err).to.exist()
-            expect(err.message).to.oneOf([
+            expect(err.message).to.contain.oneOf([
               'No such file',
-              'no link named "does-not-exist" under Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'])
+              'no link named "does-not-exist" under Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
+            ])
           })
       })
 


### PR DESCRIPTION
Adds tests for cat errors when dealing with nested links. If `No such file` is still needed as a valid value, I can add it back.