### PR TITLE
Spec and Test update to support ipfs/js-ipfs#1229

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -166,6 +166,7 @@ pull(
 ipfsPath can be of type:
 
 - [`cid`][cid] of type:
+  - a [CID](https://github.com/ipfs/js-cid) instance
   - [Buffer][b], the raw Buffer of the cid
   - String, the base58 encoded version of the cid
 - String, including the ipfs handler, a cid and a path to traverse to, ie:

--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -203,6 +203,7 @@ A great source of [examples][] can be found in the tests for this API.
 ipfsPath can be of type:
 
 - [`cid`][cid] of type:
+  - a [CID](https://github.com/ipfs/js-cid) instance
   - [Buffer][b], the raw Buffer of the cid
   - String, the base58 encoded version of the cid
 - String, including the ipfs handler, a cid and a path to traverse to, ie:

--- a/js/src/files.js
+++ b/js/src/files.js
@@ -18,6 +18,7 @@ const through = require('through2')
 const path = require('path')
 const bl = require('bl')
 const isNode = require('detect-node')
+const CID = require('cids')
 
 module.exports = (common) => {
   describe('.files', function () {
@@ -368,6 +369,16 @@ module.exports = (common) => {
       it('with a multihash', (done) => {
         const cid = Buffer.from(bs58.decode(smallFile.cid))
 
+        ipfs.files.cat(cid, (err, data) => {
+          expect(err).to.not.exist()
+          expect(data.toString()).to.contain('Plz add me!')
+          done()
+        })
+      })
+
+      it('with a cid object', (done) => {
+        const cid = new CID(smallFile.cid)
+      
         ipfs.files.cat(cid, (err, data) => {
           expect(err).to.not.exist()
           expect(data.toString()).to.contain('Plz add me!')


### PR DESCRIPTION
This has no dependencies

* Adds the spec to cat files with cid instances
* Adds the failing test for implementation

I'll be submitting PRs to add this functionality to the ipfs/js-ipfs and ipfs/js-ipfs-api repos.

connects ipfs/js-ipfs#1229