### PR TITLE
doc: You can't ipfs.add a path

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -16,7 +16,6 @@ Where `data` may be:
 - a [`Buffer instance`][b]
 - a [`Readable Stream`][rs]
 - a [`Pull Stream`][ps]
-- a Path (caveat: will only work in Node.js)
 - a URL
 - an array of objects, each of the form:
 ```JavaScript

--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -16,7 +16,6 @@ Where `data` may be:
 - a [`Buffer instance`][b]
 - a [`Readable Stream`][rs]
 - a [`Pull Stream`][ps]
-- a URL
 - an array of objects, each of the form:
 ```JavaScript
 {


### PR DESCRIPTION
The tests in js-ipfs-api explicitly assert that passing a file path string to `ipfs.add` should fail. 

https://github.com/ipfs/interface-ipfs-core/blob/b862a12bc655954143b995887983f96201abcf31/js/src/files.js#L144-L151

This PR removes "a Path" from the list of possible parameter types to `ipfs.add`

Fixes https://github.com/ipfs/js-ipfs-api/issues/722