### PR TITLE
feat: add wrapWithDirectory to files.add et al

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -31,6 +31,7 @@ If no `content` is passed, then the path is treated as an empty directory
 - progress (function): a function that will be called with the byte length of chunks as a file is added to ipfs.
 - recursive (boolean): for when a Path is passed, this option can be enabled to add recursively all the files.
 - hashAlg || hash (string): multihash hashing algorithm to use
+- wrapWithDirectory (boolean): adds a wrapping node around the content
 
 `callback` must follow `function (err, res) {}` signature, where `err` is an error if the operation was not successful. `res` will be an array of:
 
@@ -83,6 +84,7 @@ Returns a Readable Stream of class Duplex, where objects can be written of the f
 - cid-version (integer, default 0): the CID version to use when storing the data (storage keys are based on the CID, including it's version)
 - progress (function): a function that will be called with the byte length of chunks as a file is added to ipfs.
 - hashAlg || hash (string): multihash hashing algorithm to use
+- wrapWithDirectory (boolean): adds a wrapping node around the content
 
 **Example:**
 
@@ -131,6 +133,7 @@ Returns a Pull Stream, where objects can be written of the forms
 - cid-version (integer, default 0): the CID version to use when storing the data (storage keys are based on the CID, including it's version)
 - progress (function): a function that will be called with the byte length of chunks as a file is added to ipfs.
 - hashAlg || hash (string): multihash hashing algorithm to use
+- wrapWithDirectory (boolean): adds a wrapping node around the content
 
 **Example:**
 

--- a/js/src/files.js
+++ b/js/src/files.js
@@ -31,10 +31,16 @@ module.exports = (common) => {
       return loadFixture(path, 'interface-ipfs-core')
     }
 
+    const wrapDirectory = {
+      path: 'wrapper/',
+      cid: 'QmbzKtHxQXJnWG9VR66TscUfcoK3CV4nceRsCdyAEsEj9A'
+    }
+
     const smallFile = {
       cid: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
       data: fixture('js/test/fixtures/testfile.txt')
     }
+
     const bigFile = {
       cid: 'Qme79tX2bViL26vNjPsF3DP1R9rMKMvnPYJiKTTKPrXJjq',
       data: fixture('js/test/fixtures/15mb.random')
@@ -256,6 +262,19 @@ module.exports = (common) => {
           done()
         })
       })
+
+      it('wrapWithDirectory', (done) => {
+        return ipfs.files.add({ path: 'testfile.txt', content: smallFile.data }, { wrapWithDirectory: true }, (err, filesAdded) => {
+          expect(err).to.not.exist();
+          expect(filesAdded).to.have.length(2);
+          const file = filesAdded[0];
+          const wrapped = filesAdded[1]
+          expect(file.hash).to.equal(smallFile.cid)
+          expect(file.path).to.equal('testfile.txt')
+          expect(wrapped.path).to.equal(wrapDirectory.cid);
+          done();
+        });
+      });
 
       it('Promise test', () => {
         return ipfs.files.add(smallFile.data)


### PR DESCRIPTION
For https://github.com/ipfs/js-ipfs/issues/1178

Adds docs and test for new `wrapWithDirectory` parameter for files.add, files.addStream etc.

Will rely on two other PRs which will also be linked to in that issue.