### PR TITLE
docs: add TOC to specs

### DIFF
--- a/SPEC/BITSWAP.md
+++ b/SPEC/BITSWAP.md
@@ -4,9 +4,13 @@
 * [bitswap.unwant](#bitswapunwant)
 * [bitswap.stat](#bitswapstat)
 
-#### `bitswap.wantlist` (not spec'ed yet)
+#### `bitswap.wantlist`
 
-#### `bitswap.unwant` (not spec'ed yet)
+(not spec'ed yet)
+
+#### `bitswap.unwant`
+
+(not spec'ed yet)
 
 #### `bitswap.stat`
 

--- a/SPEC/BITSWAP.md
+++ b/SPEC/BITSWAP.md
@@ -1,11 +1,14 @@
-Bitswap API
-=======
+# Bitswap API
 
-#### `wantlist` (not spec'ed yet)
+* [bitswap.wantlist](#bitswapwantlist)
+* [bitswap.unwant](#bitswapunwant)
+* [bitswap.stat](#bitswapstat)
 
-#### `unwant` (not spec'ed yet)
+#### `bitswap.wantlist` (not spec'ed yet)
 
-#### `stat`
+#### `bitswap.unwant` (not spec'ed yet)
+
+#### `bitswap.stat`
 
 > Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
 

--- a/SPEC/BLOCK.md
+++ b/SPEC/BLOCK.md
@@ -1,7 +1,10 @@
-block API
-=========
+# Block API
 
-#### `get`
+* [block.get](#blockget)
+* [block.put](#blockput)
+* [block.stat](#blockstat)
+
+#### `block.get`
 
 > Get a raw IPFS block.
 
@@ -37,7 +40,7 @@ ipfs.block.get(cid, function (err, block) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `put`
+#### `block.put`
 
 > Stores input as an IPFS block.
 
@@ -107,7 +110,7 @@ ipfs.block.put(blob, cid, (err, block) => {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `stat`
+#### `block.stat`
 
 > Print information of a raw IPFS block.
 

--- a/SPEC/BOOTSTRAP.md
+++ b/SPEC/BOOTSTRAP.md
@@ -1,13 +1,16 @@
-Bootstrap API
-=============
+# Bootstrap API
 
 > Manipulates the `bootstrap list`, which contains
   the addresses of the bootstrap nodes. These are the trusted peers from
   which to learn about other peers in the network.
-  
+
 > Only edit this list if you understand the risks of adding or removing nodes from this list.
 
-#### `add`
+* [bootstrap.add](#bootstrapadd)
+* [bootstrap.list](#bootstraplist)
+* [bootstrap.rm](#bootstraprm)
+
+#### `bootstrap.add`
 
 > Add a peer address to the bootstrap list
 
@@ -19,7 +22,7 @@ Bootstrap API
 - `opts.default` if true, add the default peers to the list
 - `callback` must follow `function (err, res) {}` signature, where `err` is an error if the operation was not successful. `res.Peers` is an array of added addresses.
 
-#### `list`
+#### `bootstrap.list`
 
 > List all peer addresses in the bootstrap list
 
@@ -30,7 +33,7 @@ Bootstrap API
 - `callback` must follow `function (err, res) {}` signature, where `err` is an error if the operation was not successful. `res.Peers` is an array of addresses.
 
 
-#### `rm`
+#### `bootstrap.rm`
 
 > Remove a peer address from the bootstrap list
 

--- a/SPEC/CONFIG.md
+++ b/SPEC/CONFIG.md
@@ -1,5 +1,8 @@
-config API
-==========
+# Config API
+
+* [config.get](#configget)
+* [config.set](#configset)
+* [config.replace](#configreplace)
 
 #### `config.get`
 

--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -1,7 +1,10 @@
-dag API
-=======
+# DAG API
 
 > The dag API comes to replace the `object API`, it support the creation and manipulation of dag-pb object, as well as other IPLD formats (i.e dag-cbor, ethereum-block, git, etc)
+
+* [dag.put](#dagput)
+* [dag.get](#dagget)
+* [dag.tree](#dagtree)
 
 #### `dag.put`
 

--- a/SPEC/DHT.md
+++ b/SPEC/DHT.md
@@ -1,7 +1,13 @@
-DHT API
-=======
+# DHT API
 
-#### `findpeer`
+* [dht.findpeer](#dhtfindpeer)
+* [dht.findprovs](#dhtfindprovs)
+* [dht.get](#dhtget)
+* [dht.provide](#dhtprovide)
+* [dht.put](#dhtput)
+* [dht.query](#dhtquery)
+
+#### `dht.findpeer`
 
 > Retrieve the Peer Info of a reachable node in the network.
 
@@ -27,7 +33,7 @@ ipfs.dht.findpeer(id, function (err, peerInfo) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `findprovs`
+#### `dht.findprovs`
 
 > Retrieve the providers for content that is addressed by an hash.
 
@@ -49,7 +55,7 @@ ipfs.dht.findprovs(multihash, function (err, peerInfos) {})
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `get`
+#### `dht.get`
 
 > Retrieve a value from DHT
 
@@ -71,7 +77,7 @@ ipfs.dht.get(key, function (err, value) {})
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `provide`
+#### `dht.provide`
 
 > Announce to the network that you are providing given values.
 
@@ -93,7 +99,7 @@ ipfs.dht.provide(cid, function (err) {})
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `put`
+#### `dht.put`
 
 > Store a value on the DHT
 
@@ -103,7 +109,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 Where `key` is a string and `value` can be of any type.
 
-`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful. 
+`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful.
 
 If no `callback` is passed, a promise is returned.
 
@@ -115,7 +121,7 @@ ipfs.dht.put(key, value, function (err) {})
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `query`
+#### `dht.query`
 
 > Queries the network for the 'closest peers' to a given key. 'closest' is defined by the rules of the underlying Peer Routing mechanism.
 

--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -1,9 +1,30 @@
-files API
-=========
+# Files API
 
 > The files API enables users to use the File System abstraction of IPFS.
 
-#### `add`
+* [files.add](#filesadd)
+* [files.addReadableStream](#filesaddreadablestream)
+* [files.addPullStream](#filesaddpullstream)
+* [files.cat](#filescat)
+* [files.catReadableStream](#filescatreadablestream)
+* [files.catPullStream](#filescatpullstream)
+* [files.get](#filesget)
+* [files.getReadableStream](#filesgetreadablestream)
+* [files.getPullStream](#filesgetpullstream)
+* [ls](#ls)
+* [lsReadableStream](#lsreadablestream)
+* [lsPullStream](#lspullstream)
+* [files.cp](#filescp)
+* [files.mkdir](#filesmkdir)
+* [files.stat](#filesmkdir)
+* [files.rm](#filesrm)
+* [files.read](#filesread)
+* [files.write](#fileswrite)
+* [files.mv](#filesmv)
+* [files.flush](#filesflush)
+* [files.ls](#filesls)
+
+#### `files.add`
 
 > Add files and data to IPFS.
 
@@ -63,7 +84,7 @@ ipfs.files.add(files, function (err, files) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `addReadableStream`
+#### `files.addReadableStream`
 
 > Add files and data to IPFS using a [Readable Stream][rs] of class Duplex.
 
@@ -112,7 +133,7 @@ stream.end()
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `addPullStream`
+#### `files.addPullStream`
 
 > Add files and data to IPFS using a [Pull Stream][ps].
 
@@ -157,7 +178,7 @@ pull(
 )
 ```
 
-#### `cat`
+#### `files.cat`
 
 > Returns a file addressed by a valid IPFS Path.
 
@@ -198,7 +219,7 @@ ipfs.files.cat(ipfsPath, function (err, file) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `catReadableStream`
+#### `files.catReadableStream`
 
 > Returns a [Readable Stream][rs] containing the contents of a file addressed by a valid IPFS Path.
 
@@ -231,7 +252,7 @@ const stream = ipfs.files.catReadableStream(ipfsPath)
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `catPullStream`
+#### `files.catPullStream`
 
 > Returns a [Pull Stream][ps] containing the contents of a file addressed by a valid IPFS Path.
 
@@ -263,7 +284,7 @@ const stream = ipfs.files.catPullStream(ipfsPath)
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `get`
+#### `files.get`
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path.
 
@@ -309,7 +330,7 @@ ipfs.files.get(validCID, function (err, files) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `getReadableStream`
+#### `files.getReadableStream`
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path. The files will be yielded as Readable Streams.
 
@@ -357,7 +378,7 @@ stream.on('data', (file) => {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `getPullStream`
+#### `files.getPullStream`
 
 > Fetch a file or an entire directory tree from IPFS that is addressed by a valid IPFS Path. The files will be yielded as Readable Streams.
 
@@ -496,7 +517,7 @@ It returns a [Readable Stream][rs] in [Object mode](https://nodejs.org/api/strea
 ```JavaScript
 const validCID = 'QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF'
 
-const stream = ipfs.files.lsReadableStream(validCID)
+const stream = ipfs.lsReadableStream(validCID)
 
 stream.on('data', (file) => {
   // write the file's path and contents to standard out
@@ -545,7 +566,7 @@ It returns a [Pull Stream][os] that will yield objects of the form:
 ```JavaScript
 const validCID = 'QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF'
 
-const stream = ipfs.files.lsPullStream(validCID)
+const stream = ipfs.lsPullStream(validCID)
 
 pull(
   stream,
@@ -561,16 +582,14 @@ pull(
 
 A great source of [examples][] can be found in the tests for this API.
 
---------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------
+---
 
-Mutable File System
-===================
+## Mutable File System
 
 The Mutable File System (MFS) is a virtual file system on top of IPFS that exposes a Unix like API over a virtual directory. It enables users to write and read from paths without having to worry about updating the graph. It enables things like [ipfs-blob-store](https://github.com/ipfs/ipfs-blob-store) to exist.
 
 
-#### `cp`
+#### `files.cp`
 
 > Copy files.
 
@@ -597,7 +616,7 @@ ipfs.files.cp(['/src-file', '/dst-file'], (err) => {
 })
 ```
 
-#### `mkdir`
+#### `files.mkdir`
 
 > Make a directory.
 
@@ -625,7 +644,7 @@ ipfs.files.mkdir('/my/beautiful/directory', (err) => {
 })
 ```
 
-#### `stat`
+#### `files.stat`
 
 > Get file or directory status.
 
@@ -671,7 +690,7 @@ ipfs.files.stat('/file.txt', (err, stats) => {
 // }
 ```
 
-#### `rm`
+#### `files.rm`
 
 > Remove a file or directory.
 
@@ -707,7 +726,7 @@ ipfs.files.rm('/my/beautiful/directory', { recursive: true }, (err) => {
 })
 ```
 
-#### `read`
+#### `files.read`
 
 > Read a file.
 
@@ -736,7 +755,7 @@ ipfs.files.read('/hello-world', (err, buf) => {
 // Hello, World!
 ```
 
-#### `write`
+#### `files.write`
 
 > Write to a file.
 
@@ -768,7 +787,7 @@ ipfs.files.write('/hello-world', Buffer.from('Hello, world!'), (err) => {
 })
 ```
 
-#### `mv`
+#### `files.mv`
 
 > Move files.
 
@@ -795,7 +814,7 @@ ipfs.files.mv(['/src-file', '/dst-file'], (err) => {
 })
 ```
 
-#### `flush`
+#### `files.flush`
 
 > Flush a given path's data to the disk
 
@@ -821,7 +840,7 @@ ipfs.files.flush('/', (err) => {
 })
 ```
 
-#### `ls`
+#### `files.ls`
 
 > List directories in the local mutable namespace.
 
@@ -834,7 +853,7 @@ Where:
 - `path` is the path to show listing for. Defaults to `/`.
 - `options` is an optional Object that might contain the following keys:
   - `l` is a Boolean value o use long listing format.
-  
+
 `callback` must follow `function (err, files) {}` signature, where `err` is an error if the operation was not successful. `files` is an array containing Objects that contain the following keys:
 
 - `name` which is the file's name.

--- a/SPEC/KEY.md
+++ b/SPEC/KEY.md
@@ -1,7 +1,13 @@
-Key API
-=======
+# Key API
 
-#### `gen`
+* [key.gen](#keygen)
+* [key.list](#keylist)
+* [key.rm](#keyrm)
+* [key.rename](#keyrename)
+* [key.export](#keyexport)
+* [key.import](#keyimport)
+
+#### `key.gen`
 
 > Generate a new key
 
@@ -32,7 +38,7 @@ ipfs.key.gen('my-key', {
 //  name: 'my-key' }
 ```
 
-#### `list`
+#### `key.list`
 
 > List all the keys
 
@@ -64,7 +70,7 @@ ipfs.key.list((err, keys) => console.log(keys))
 // ]
 ```
 
-#### `rm`
+#### `key.rm`
 
 > Remove a key
 
@@ -95,7 +101,7 @@ ipfs.key.rm('my-key', (err, key) => console.log(key))
 //   name: 'my-key' }
 ```
 
-#### `rename`
+#### `key.rename`
 
 > Rename a key
 
@@ -122,7 +128,7 @@ ipfs.key.rename('my-key', 'my-new-key', (err, key) => console.log(key))
 //   overwrite: false }
 ```
 
-#### `export`
+#### `key.export`
 
 > Export a key in a PEM encoded password protected PKCS #8
 
@@ -150,7 +156,7 @@ ipfs.key.export('self', 'password', (err, pem) => console.log(pem))
 // -----END ENCRYPTED PRIVATE KEY-----
 ```
 
-#### `import`
+#### `key.import`
 
 > Import a PEM encoded password protected PKCS #8 key
 

--- a/SPEC/MISCELLANEOUS.md
+++ b/SPEC/MISCELLANEOUS.md
@@ -1,5 +1,9 @@
-Miscellaneous API
-===========
+# Miscellaneous API
+
+* [id](#id)
+* [version](#version)
+* [dns](#dns)
+* [stop](#stop)
 
 #### `id`
 
@@ -86,14 +90,14 @@ A great source of [examples][] can be found in the tests for this API.
 
 ##### `JavaScript` - ipfs.stop([callback])
 
-`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful. 
+`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful.
 If no `callback` is passed, a promise is returned.
 
 **Example:**
 
 ```JavaScript
 ipfs.stop((err) => {
-  if (err) { 
+  if (err) {
     throw err
   }
 })

--- a/SPEC/NAME.md
+++ b/SPEC/NAME.md
@@ -1,7 +1,9 @@
-Name API
-========
+# Name API
 
-#### `publish`
+* [name.publish](#namepublish)
+* [name.resolve](#nameresolve)
+
+#### `name.publish`
 
 > Publish an IPNS name with a given value.
 
@@ -22,7 +24,7 @@ Name API
 }
 ```
 
-`callback` must follow `function (err, name) {}` signature, where `err` is an error if the operation was not successful. `name` is an object that contains the IPNS hash and the IPFS hash, such as: 
+`callback` must follow `function (err, name) {}` signature, where `err` is an error if the operation was not successful. `name` is an object that contains the IPNS hash and the IPFS hash, such as:
 
 ```JavaScript
 {
@@ -53,7 +55,7 @@ ipfs.name.publish(addr, function (err, res) {
 
 This way, you can republish a new version of your website under the same address. By default, `ipfs.name.publish` will use the Peer ID. If you want to have multiple websites (for example) under the same IPFS module, you can always check the [key API](./KEY.md).
 
-#### `resolve`
+#### `name.resolve`
 
 > Resolve an IPNS name.
 

--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -6,7 +6,7 @@
 * [object.data](#objectdata)
 * [object.links](#objectlinks)
 * [object.stat](#objectstat)
-* [object.patch.addLink](#objectpatch)
+* [object.patch.addLink](#objectpatchaddlink)
 * [object.patch.rmLink](#objectpatchrmlink)
 * [object.patch.appendData](#objectpatchappenddata)
 * [object.patch.setData](#objectpatchsetdata)

--- a/SPEC/OBJECT.md
+++ b/SPEC/OBJECT.md
@@ -1,5 +1,15 @@
-object API
-==========
+# Object API
+
+* [object.new](#objectnew)
+* [object.put](#objectput)
+* [object.get](#objectget)
+* [object.data](#objectdata)
+* [object.links](#objectlinks)
+* [object.stat](#objectstat)
+* [object.patch.addLink](#objectpatch)
+* [object.patch.rmLink](#objectpatchrmlink)
+* [object.patch.appendData](#objectpatchappenddata)
+* [object.patch.setData](#objectpatchsetdata)
 
 #### `object.new`
 
@@ -142,6 +152,7 @@ ipfs.object.data(multihash, (err, data) => {
   console.log(data.toString())
   // Logs:
   // some data
+})
 ```
 
 A great source of [examples][] can be found in the tests for this API.
@@ -179,6 +190,7 @@ ipfs.object.links(multihash, (err, links) => {
   console.log(links)
   // Logs:
   // []
+})
 ```
 
 A great source of [examples][] can be found in the tests for this API.
@@ -260,7 +272,7 @@ A great source of [examples][] can be found in the tests for this API.
 - `DAGLink`
 - Object containing: name, multihash and size properties
 
-```
+```js
 const link = {
   name: 'Qmef7ScwzJUCg1zUSrCmPAz45m8uP5jU7SLgt2EffjBmbL',
   size: 37,
@@ -270,7 +282,7 @@ const link = {
 
 or
 
-```
+```js
 const link = new DAGLink(name, size, multihash)
 ```
 
@@ -316,7 +328,7 @@ A great source of [examples][] can be found in the tests for this API.
 - `DAGLink`
 - Object containing name property
 
-```
+```js
 const link = {
   name: 'Qmef7ScwzJUCg1zUSrCmPAz45m8uP5jU7SLgt2EffjBmbL'
 };
@@ -324,7 +336,7 @@ const link = {
 
 or
 
-```
+```js
 const link = new DAGLink(name, size, multihash)
 ```
 

--- a/SPEC/PIN.md
+++ b/SPEC/PIN.md
@@ -1,7 +1,10 @@
-Pin API
-=======
+# Pin API
 
-#### `add`
+* [pin.add](#pinadd)
+* [pin.ls](#pinls)
+* [pin.rm](#pinrm)
+
+#### `pin.add`
 
 > Adds an IPFS object to the pinset and also stores it to the IPFS repo. pinset is the set of hashes currently pinned (not gc'able).
 
@@ -21,7 +24,7 @@ Where:
 {
   hash: 'QmHash'
 }
-``` 
+```
 
 If no `callback` is passed, a promise is returned.
 
@@ -31,7 +34,7 @@ If no `callback` is passed, a promise is returned.
 ipfs.pin.add(hash, function (err) {})
 ```
 
-#### `ls`
+#### `pin.ls`
 
 > List all the objects pinned to local storage or under a specific hash.
 
@@ -62,7 +65,7 @@ ipfs.pin.ls(function (err, pinset) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `rm`
+#### `pin.rm`
 
 > Remove a hash from the pinset
 
@@ -75,7 +78,7 @@ Where:
 - `options` is an object that can contain the following keys
   - 'recursive' - Recursively unpin the object linked. Type: bool. Default: `false`
 
-`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful. 
+`callback` must follow `function (err) {}` signature, where `err` is an error if the operation was not successful.
 
 If no `callback` is passed, a promise is returned.
 

--- a/SPEC/PUBSUB.md
+++ b/SPEC/PUBSUB.md
@@ -1,5 +1,10 @@
-pubsub API
-==========
+# PubSub API
+
+* [pubsub.subscribe](#pubsubsubscribe)
+* [pubsub.unsubscribe](#pubsubunsubscribe)
+* [pubsub.publish](#pubsubpublish)
+* [pubsub.ls](#pubsubls)
+* [pubsub.peers](#pubsubpeers)
 
 #### `pubsub.subscribe`
 

--- a/SPEC/REPO.md
+++ b/SPEC/REPO.md
@@ -1,7 +1,10 @@
-Repo API
-=======
+# Repo API
 
-#### `gc`
+* [repo.gc](#repogc)
+* [repo.stat](#repostat)
+* [repo.version](#repoversion)
+
+#### `repo.gc`
 
 > Perform a garbage collection sweep on the repo.
 
@@ -25,7 +28,7 @@ If no `callback` is passed, a promise is returned.
 ipfs.repo.gc((err, res) => console.log(res))
 ```
 
-#### `stat`
+#### `repo.stat`
 
 > Get stats for the currently used repo.
 
@@ -62,7 +65,7 @@ ipfs.repo.stat((err, stats) => console.log(stats))
 //   storageMax: 10000000000 }
 ```
 
-#### `version`
+#### `repo.version`
 
 > Show the repo version.
 

--- a/SPEC/STATS.md
+++ b/SPEC/STATS.md
@@ -1,15 +1,20 @@
-Stats API
-=======
+# Stats API
 
-#### `bitswap`
+* [stats.bitswap](#statsbitswap)
+* [stats.repo](#statsrepo)
+* [stats.bw](#statsbw)
+* [stats.bwPullStream](#statsbwpullstream)
+* [stats.bwReadableStream](#statsbwreadablestream)
+
+#### `stats.bitswap`
 
 `stats.bitswap` and `bitswap.stat` can be used interchangeably. See [`bitswap.stat`](./BITSWAP.md#stat) for more details.
 
-#### `repo`
+#### `stats.repo`
 
 `stats.repo` and `repo.stat` can be used interchangeably. See [`repo.stat`](./REPO.md#stat) for more details.
 
-#### `bw`
+#### `stats.bw`
 
 > Get IPFS bandwidth information as an object.
 
@@ -47,7 +52,7 @@ ipfs.stats.bw((err, stats) => console.log(stats))
 //   rateOut: Big {...} }
 ```
 
-#### `bwPullStream`
+#### `stats.bwPullStream`
 
 > Get IPFS bandwidth information as a [Pull Stream][ps].
 
@@ -78,7 +83,7 @@ pull(
 // Ad infinitum
 ```
 
-#### `bwReadableStream`
+#### `stats.bwReadableStream`
 
 > Get IPFS bandwidth information as a [Readable Stream][rs].
 

--- a/SPEC/SWARM.md
+++ b/SPEC/SWARM.md
@@ -1,7 +1,13 @@
-Swarm API
-=========
+# Swarm API
 
-#### `addrs`
+* [swarm.addrs](#swarmaddrs)
+* [swarm.connect](#swarmconnect)
+* [swarm.disconnect](#swarmdisconnect)
+* [swarm.peers](#swarmpeers)
+* [swarm.filters.add](#swarmfiltersadd)
+* [swarm.filters.rm](#swarmfiltersrm)
+
+#### `swarm.addrs`
 
 > List of known addresses of each peer connected.
 
@@ -26,7 +32,7 @@ ipfs.swarm.addrs(function (err, addrs) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `connect`
+#### `swarm.connect`
 
 > Open a connection to a given address.
 
@@ -53,7 +59,7 @@ ipfs.swarm.connect(addr, function (err) {
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `disconnect`
+#### `swarm.disconnect`
 
 > Close a connection on a given address.
 
@@ -75,7 +81,7 @@ ipfs.swarm.disconnect(addr, function (err) {})
 
 A great source of [examples][] can be found in the tests for this API.
 
-#### `peers`
+#### `swarm.peers`
 
 > List out the peers that we have connections with.
 
@@ -115,7 +121,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 > NOT IMPLEMENTED YET
 
-#### `filters`
+#### `swarm.filters`
 
 > Display current multiaddr filters. Filters are a way to set up rules for the network connections established.
 
@@ -133,7 +139,7 @@ Example:
 ipfs.swarm.filters(function (err, filters) {})
 ```
 
-#### `filters.add`
+#### `swarm.filters.add`
 
 > Add another filter.
 
@@ -153,7 +159,7 @@ Example:
 ipfs.swarm.filters.add(filter, function (err) {})
 ```
 
-#### `filters.rm`
+#### `swarm.filters.rm`
 
 > Remove a filter
 

--- a/SPEC/TYPES.md
+++ b/SPEC/TYPES.md
@@ -1,5 +1,4 @@
-TYPES API
-=======
+# Types API
 
 A set of data types are exposed directly from the IPFS instance under `ipfs.types`. That way you're not required to import/require the following.
 

--- a/SPEC/UTIL.md
+++ b/SPEC/UTIL.md
@@ -1,5 +1,4 @@
-UTIL API
-=======
+# Util API
 
 A set of utils are exposed directly from the IPFS instance under `ipfs.util`. That way you're not required to import/require the following:
 


### PR DESCRIPTION
For overview of commands and quick navigation to point on the page the docs are at.

Also tidies up main headings and ensures all commands are prefixed with the subsystem they're in (if any).