### PR TITLE
fix(pubsub): clear interval on error

### DIFF
--- a/js/src/pubsub.js
+++ b/js/src/pubsub.js
@@ -21,6 +21,7 @@ function waitForPeers (ipfs, topic, peersToWait, callback) {
   const i = setInterval(() => {
     ipfs.pubsub.peers(topic, (err, peers) => {
       if (err) {
+        clearInterval(i)
         return callback(err)
       }
 


### PR DESCRIPTION
It is cleared before success callback but not on error.

Previously if this failed it would call the callback again and again every 500ms unleashing chaos on the rest of the tests.