### PR TITLE
fix(ping): wait until nodes are connected before starting ping tests

### DIFF
--- a/js/src/ping.js
+++ b/js/src/ping.js
@@ -28,7 +28,7 @@ module.exports = (common) => {
     let ipfsdB
 
     before(function (done) {
-      this.timeout(30 * 1000)
+      this.timeout(60 * 1000)
 
       common.setup((err, factory) => {
         if (err) return done(err)

--- a/js/src/ping.js
+++ b/js/src/ping.js
@@ -23,7 +23,7 @@ function expectIsPingResponse (obj) {
 }
 
 module.exports = (common) => {
-  describe.only('.ping', function () {
+  describe('.ping', function () {
     let ipfsdA
     let ipfsdB
 

--- a/js/src/utils/connections.js
+++ b/js/src/utils/connections.js
@@ -7,7 +7,7 @@ function waitUntilConnected (fromNode, toNode, opts, cb) {
   }
 
   opts = opts || {}
-  opts.timeout = opts.timeout || 15000
+  opts.timeout = opts.timeout || 30000
   opts.interval = opts.interval || 1000
 
   const startTime = Date.now()

--- a/js/src/utils/connections.js
+++ b/js/src/utils/connections.js
@@ -1,0 +1,51 @@
+const waterfall = require('async/waterfall')
+
+function waitUntilConnected (fromNode, toNode, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+
+  opts = opts || {}
+  opts.timeout = opts.timeout || 15000
+  opts.interval = opts.interval || 1000
+
+  const startTime = Date.now()
+  const checkConnected = () => {
+    isConnected(fromNode, toNode, (err, connected) => {
+      if (err) return cb(err)
+      if (connected) return cb()
+
+      if (Date.now() > startTime + opts.timeout) {
+        return cb(new Error('timeout waiting for connected nodes'))
+      }
+
+      setTimeout(checkConnected, opts.interval)
+    })
+  }
+
+  checkConnected()
+}
+
+exports.waitUntilConnected = waitUntilConnected
+
+function isConnected (fromNode, toNode, cb) {
+  waterfall([
+    (cb) => {
+      if (toNode.peerId) return cb(null, toNode.peerId)
+      toNode.id((err, id) => {
+        if (err) return cb(err)
+        toNode.peerId = id
+        cb(null, id)
+      })
+    },
+    (toPeerId, cb) => {
+      fromNode.swarm.peers((err, peers) => {
+        if (err) return cb(err)
+        cb(null, peers.some((p) => p.peer.toJSON().id === toPeerId.id))
+      })
+    }
+  ], cb)
+}
+
+exports.isConnected = isConnected


### PR DESCRIPTION
This PR simply changes the ping tests to wait for the two nodes to be connected before starting.

We poll `swarm.peers` every second to check for connectivity and times out after 30s. It means we can distinguish between actual test failures and connectivity problems in the tests.