### PR TITLE
test: adds test vulnerable to encoding translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dirty-chai": "^2.0.1",
     "hat": "0.0.3",
     "ipfs-block": "~0.7.1",
+    "ipfs-unixfs": "~0.1.15",
     "ipld-dag-cbor": "~0.12.1",
     "ipld-dag-pb": "~0.14.5",
     "is-ipfs": "~0.3.2",


### PR DESCRIPTION
This follows on from ipfs/js-ipfs#1398 and tests the more general case.

Seems to fail with the current master of js-ipfs-api.