### PR TITLE
test: add test for retrieving an empty block

### DIFF
--- a/js/src/block.js
+++ b/js/src/block.js
@@ -123,6 +123,22 @@ module.exports = (common) => {
         })
       })
 
+      it('should get an empty block', (done) => {
+        ipfs.block.put(Buffer.alloc(0), {
+          format: 'dag-pb',
+          mhtype: 'sha2-256',
+          version: 0
+        }, (err, block) => {
+          expect(err).to.not.exist()
+
+          ipfs.block.get(block.cid, (err, block) => {
+            expect(err).to.not.exist()
+            expect(block.data).to.eql(Buffer.alloc(0))
+            done()
+          })
+        })
+      })
+
       // TODO it.skip('Promises support', (done) => {})
     })
 


### PR DESCRIPTION
Add an empty block and ensure we can get it back successfully. Test for https://github.com/ipfs/js-ipfs-api/pull/789