### PR TITLE
chore: re-enable linting

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,8 @@
+module.exports = {
+  lint: {
+    files: [
+      'js/src/**/*.js',
+      'js/test/**/*.js'
+    ]
+  }
+}

--- a/js/src/files-mfs.js
+++ b/js/src/files-mfs.js
@@ -315,7 +315,7 @@ module.exports = (common) => {
           this.skip()
         }
 
-        ipfs.files.stat('/test/b', {'withLocal': true}, (err, stat) => {
+        ipfs.files.stat('/test/b', {withLocal: true}, (err, stat) => {
           expect(err).to.not.exist()
           expect(stat).to.eql({
             type: 'file',
@@ -338,7 +338,7 @@ module.exports = (common) => {
           this.skip()
         }
 
-        ipfs.files.stat('/test', {'withLocal': true}, (err, stat) => {
+        ipfs.files.stat('/test', {withLocal: true}, (err, stat) => {
           expect(err).to.not.exist()
           expect(stat).to.eql({
             type: 'directory',

--- a/js/src/utils/connections.js
+++ b/js/src/utils/connections.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const waterfall = require('async/waterfall')
 
 function waitUntilConnected (fromNode, toNode, opts, cb) {

--- a/js/src/utils/spawn.js
+++ b/js/src/utils/spawn.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const waterfall = require('async/waterfall')
 const timesSeries = require('async/timesSeries')
 


### PR DESCRIPTION
When the JS code was moved into the js/ directory the aegir linting task was no longer considering them for linting. This is because the default globs do not include this path.

This PR adds custom lint globs to the aegir config and fixes linting errors.

depends on https://github.com/ipfs/aegir/pull/240