### PR TITLE
fix: allow skip with object but no reason

### DIFF
--- a/js/src/utils/mocha.js
+++ b/js/src/utils/mocha.js
@@ -8,6 +8,8 @@ chai.use(dirtyChai)
 
 module.exports.expect = chai.expect
 
+const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]'
+
 // Get a "describe" function that is optionally 'skipped' or 'onlyed'
 // If skip/only are boolean true, or an object with a reason property, then we
 // want to skip/only the whole suite
@@ -16,7 +18,9 @@ function getDescribe (config) {
     if (config.only === true) return describe.only
     if (config.skip === true) return describe.skip
 
-    if (config.skip && typeof config.skip === 'object' && config.skip.reason) {
+    if (isObject(config.skip)) {
+      if (!config.skip.reason) return describe.skip
+
       const _describe = (name, impl) => {
         describe.skip(`${name} (${config.skip.reason})`, impl)
       }
@@ -44,7 +48,7 @@ function getIt (config) {
   const _it = (name, impl) => {
     if (Array.isArray(config.skip)) {
       const skip = config.skip
-        .map((s) => s && typeof s === 'object' ? s : { name: s })
+        .map((s) => isObject(s) ? s : { name: s })
         .find((s) => s.name === name)
 
       if (skip) {

--- a/js/src/utils/suite.js
+++ b/js/src/utils/suite.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]'
+
 function createSuite (tests, parent) {
   const suite = (createCommon, options) => {
     Object.keys(tests).forEach(t => {
@@ -8,7 +10,7 @@ function createSuite (tests, parent) {
 
       if (Array.isArray(opts.skip)) {
         const skip = opts.skip
-          .map((s) => s && typeof s === 'object' ? s : { name: s })
+          .map((s) => isObject(s) ? s : { name: s })
           .find((s) => s.name === suiteName)
 
         if (skip) {


### PR DESCRIPTION
This PR simply fixes `getDescribe` to also allow you to skip an entire suite using the object syntax (`{ name: 'test name', reason: 'why it was skipped' }`) but with only a name and not a reason. It also tightens up the check for object so that things also considered 'object' according to `typeof` don't also get through ahem `null`, `undefined`, `[]` etc.