### PR TITLE
Allow passing only to suites with skip lists

### DIFF
--- a/js/src/utils/mocha.js
+++ b/js/src/utils/mocha.js
@@ -15,7 +15,6 @@ const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]'
 // want to skip/only the whole suite
 function getDescribe (config) {
   if (config) {
-    if (config.only === true) return describe.only
     if (config.skip === true) return describe.skip
 
     if (isObject(config.skip)) {
@@ -30,6 +29,8 @@ function getDescribe (config) {
 
       return _describe
     }
+
+    if (config.only === true) return describe.only
   }
 
   return describe


### PR DESCRIPTION
If a suite of tests has a `skip` array, when adding a `only: true`, the skipped tests start to run again, which makes it hard to isolate a suite. This change allows skipped tests to be skipped and not have the `only` applied. This results in the tests not showing up in the output.

Example

```js
  tests.key(defaultCommonFactory, {
    only: true,
    skip: [
      // key.export
      {
        name: 'export',
        reason: 'TODO not implemented in go-ipfs yet'
      },
      // key.import
      {
        name: 'import',
        reason: 'TODO not implemented in go-ipfs yet'
      }
    ]
  })
```

### Output

**Before**
```
  interface-ipfs-core tests
    .key.gen
      ✓ should generate a new rsa key (106ms)
    .key.list
      ✓ should list all the keys (246ms)
    .key.rename
      ✓ should rename a key (156ms)
    .key.rm
      ✓ should rm a key (178ms)
    .key.export
      1) should export "self" key
    .key.import
      2) should import an exported key


  4 passing (3s)
  2 failing
```

**After**
```
  interface-ipfs-core tests
    .key.gen
      ✓ should generate a new rsa key (175ms)
    .key.list
      ✓ should list all the keys (182ms)
    .key.rename
      ✓ should rename a key (207ms)
    .key.rm
      ✓ should rm a key (97ms)

  4 passing (2s)
```