### PR TITLE
docs(dag): signify optional params and do it consistently

### DIFF
--- a/SPEC/DAG.md
+++ b/SPEC/DAG.md
@@ -12,7 +12,7 @@
 
 ##### `Go` **WIP**
 
-##### `JavaScript` - ipfs.dag.put(dagNode, options, callback)
+##### `JavaScript` - ipfs.dag.put(dagNode, [options], [callback])
 
 - `dagNode` - a DAG node that follows one of the supported IPLD formats.
 - `options` - a object that might contain the following values:
@@ -48,7 +48,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 ##### `Go` **WIP**
 
-##### `JavaScript` - ipfs.dag.get(cid [, path, options], callback)
+##### `JavaScript` - ipfs.dag.get(cid, [path], [options], [callback])
 
 - `cid` - can be one of the following:
   - a [CID](https://github.com/ipfs/js-cid) instance.
@@ -119,7 +119,7 @@ A great source of [examples][] can be found in the tests for this API.
 
 ##### `Go` **WIP**
 
-##### `JavaScript` - ipfs.dag.tree(cid [, path, options], callback)
+##### `JavaScript` - ipfs.dag.tree(cid, [path], [options], [callback])
 
 - `cid` - can be one of the following:
   - a [CID](https://github.com/ipfs/js-cid) instance.


### PR DESCRIPTION
Signifies params that are actually optional and does it in a way that is consistent with other spec docs.