### PR TITLE
test(dag): add test to verify put API overrides hash algorithm

### DIFF
--- a/js/src/dag/put.js
+++ b/js/src/dag/put.js
@@ -109,6 +109,18 @@ module.exports = (createCommon, options) => {
       })
     })
 
+    it('should override hash algoritm default and resolve with it', (done) => {
+      ipfs.dag.put(cborNode, {
+        format: 'dag-cbor',
+        hashAlg: 'sha3-512'
+      }, (err, cid) => {
+        expect(err).to.not.exist()
+        expect(cid.codec).to.equal('dag-cbor')
+        expect(multihash.decode(cid.multihash).name).to.equal('sha3-512')
+        done()
+      })
+    })
+
     it.skip('should put by passing the cid instead of format and hashAlg', (done) => {})
 
     // TODO it.skip('Promises support', (done) => {})


### PR DESCRIPTION
As discussed in https://github.com/ipfs/js-ipfs/pull/1419#issuecomment-402441180
at the time of this commit, `dag.put()` basically ignores the `hashAlg`
option, as it passes it down to `ipld.put()`, which won't honor it until
https://github.com/ipld/js-ipld/pull/133 is merged.

Once https://github.com/ipld/js-ipld/pull/133 is merged, this test verifies
that e.g.

```
dag.put(cborNode, {
  format: 'dag-cbor',
  hashAlg: 'sha3-512'
}, (err, cid) => {
  ...
})
```

Actually results in a `CID` instance that decodes to `sha3-512` and not
the `sha2-256` default.

License: MIT
Signed-off-by: Pascal Precht pascal.precht@gmail.com