### PR TITLE
chore: re-enable linting

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = {
+  lint: {
+    files: [
+      'js/src/**/*.js',
+      'js/test/**/*.js'
+    ]
+  }
+}

--- a/js/src/bitswap/unwant.js
+++ b/js/src/bitswap/unwant.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
 const waterfall = require('async/waterfall')

--- a/js/src/bitswap/wantlist.js
+++ b/js/src/bitswap/wantlist.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
 const waterfall = require('async/waterfall')

--- a/js/src/key/list.js
+++ b/js/src/key/list.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
 const timesSeries = require('async/timesSeries')

--- a/js/src/key/rename.js
+++ b/js/src/key/rename.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
 const chai = require('chai')

--- a/js/src/key/rm.js
+++ b/js/src/key/rm.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
 const hat = require('hat')

--- a/js/src/pubsub/subscribe.js
+++ b/js/src/pubsub/subscribe.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 6] */
 'use strict'
 
 const series = require('async/series')

--- a/js/src/utils/swarm.js
+++ b/js/src/utils/swarm.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const eachSeries = require('async/eachSeries')
 
 function connect (fromNode, toAddrs, cb) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/ipfs/interface-ipfs-core#readme",
   "dependencies": {
-    "aegir": "^14.0.0",
+    "aegir": "^15.0.0",
     "async": "^2.6.1",
     "big.js": "^5.1.2",
     "bl": "^2.0.1",


### PR DESCRIPTION
When the JS code was moved into the js/ directory the aegir linting task was no longer considering them for linting. This is because the default globs do not include this path.

This PR adds custom lint globs to the aegir config and fixes linting errors.

depends on ipfs/aegir#240

License: MIT
Signed-off-by: Alan Shaw <alan@tableflip.io>