### PR TITLE
chore: add migration note about upgrading from < 0.72.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 * unsubscribe in series for go-ipfs ([#326](https://github.com/ipfs/interface-ipfs-core/issues/326)) ([8e487da](https://github.com/ipfs/interface-ipfs-core/commit/8e487da))
 
 
+### Breaking Changes
+
+* Git pre-push hook has been removed
+
+  This can cause problems during installation of npm dependencies, in case the repository
+  is not freshly cloned. Prior to 0.72.1 a pre-push hook has been set up to verify
+  changes before sending them to a remote repository. Due to the removal, existing
+  installations will have dead symlinks that cause `npm install` to fail.
+
+  The migration path is to remove the `pre-hook` file/symlink inside `.git/hooks` of
+  your clone.
+
+  [Read this issue](https://github.com/ipfs/js-ipfs/issues/1444) for more information.
+
 
 <a name="0.72.0"></a>
 # [0.72.0](https://github.com/ipfs/interface-ipfs-core/compare/v0.71.0...v0.72.0) (2018-07-05)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 > A test suite and interface you can use to implement a IPFS core interface.
 
+### Upgrading from < 0.72.1
+
+If you're upgrading from < 0.72.1 you might run into errors when installing dependencies due to non-existing git hooks. For fixes, please refer to the [changelog](https://github.com/ipfs/interface-ipfs-core/blob/master/CHANGELOG.md#breaking-changes).
+
 ## Lead Maintainer
 
 [Alan Shaw](http://github.com/alanshaw).


### PR DESCRIPTION
Turns out that, similar to https://github.com/ipfs/js-ipfs/issues/1444, we've introduce a
regression in https://github.com/ipfs/interface-ipfs-core/commit/87a8f96b74987ab6d477dc73a91d9f32ff066267 in which we upgrade
Aegir to 15.0.0. This causes problems during installation of npm dependencies for any existing clone
of the repository as the pre-push hook becomes a dead symlink.

License: MIT
Signed-off-by: Pascal Precht <pascal.precht@gmail.com>