### PR TITLE
test(files): add test to ensure meaningful error is thrown in `cat()`

### DIFF
--- a/js/src/files/cat.js
+++ b/js/src/files/cat.js
@@ -130,6 +130,16 @@ module.exports = (createCommon, options) => {
         })
     })
 
+    it('should error on key/path with invalid encoding', () => {
+      const invalidCid = '/ipfs/QmUzdHisA7ouM8DM5rVAKursVK7t7tKeqDYGvmaCdJw5jEeesdlfjsldkfjsldkfjsdlkfjskldfj'
+
+      return ipfs.files.cat(invalidCid)
+        .catch((err) => {
+          expect(err).to.exist()
+          expect(err.toString()).to.contain('Error: selected encoding not supported')
+        })
+    })
+
     it('should error on unknown path (promised)', () => {
       return ipfs.files.cat(fixtures.smallFile.cid + '/does-not-exist')
         .catch((err) => {


### PR DESCRIPTION
To verify changes discussed in https://github.com/ipfs/js-ipfs-api/issues/799#issuecomment-402086401, this commit
adds a test that checks `files.cat()` throws a meaningful error when a key or ipfs path with
unsupported encoding is given.

License: MIT
Signed-off-by: Pascal Precht pascal.precht@gmail.com