### PR TITLE
test: make files.ls results ordering consistent

### DIFF
--- a/js/src/files/ls.js
+++ b/js/src/files/ls.js
@@ -54,8 +54,8 @@ module.exports = (createCommon, options) => {
         ipfs.files.ls(testDir, (err, info) => {
           expect(err).to.not.exist()
           expect(info).to.eql([
-            { name: 'b', type: 0, size: 0, hash: '' },
-            { name: 'lv1', type: 0, size: 0, hash: '' }
+            { name: 'lv1', type: 0, size: 0, hash: '' },
+            { name: 'b', type: 0, size: 0, hash: '' }
           ])
           done()
         })


### PR DESCRIPTION
 Previously we'd get files in different orders between `files.ls()` and `files.ls({long: true})` due to a bug in `go-ipfs` (see ipfs/go-ipfs#5181)
    
Since this has been resolved we can now expect consistent ordering.