### PR TITLE
fix: give more time for teardown after resolve

### DIFF
--- a/js/src/miscellaneous/resolve.js
+++ b/js/src/miscellaneous/resolve.js
@@ -29,7 +29,8 @@ module.exports = (createCommon, options) => {
       })
     })
 
-    after((done) => {
+    after(function (done) {
+      this.timeout(10 * 1000)
       common.teardown(done)
     })
 


### PR DESCRIPTION
Looks like this passes most of the time but sometimes takes longer than the default 5s https://ci.ipfs.team/blue/organizations/jenkins/IPFS%2Fjs-ipfs-api/detail/feat%2Fresolve-cmd-rebase/1/pipeline/17