### PR TITLE
fix: update error messages in line with go

### DIFF
--- a/js/src/files/read-readable-stream.js
+++ b/js/src/files/read-readable-stream.js
@@ -38,7 +38,7 @@ module.exports = (createCommon, options) => {
 
       const stream = ipfs.files.readReadableStream(`${testDir}/404`)
 
-      stream.on('error', (err) => {
+      stream.once('error', (err) => {
         expect(err).to.exist()
         expect(err.message).to.contain('does not exist')
         done()

--- a/js/src/files/read.js
+++ b/js/src/files/read.js
@@ -35,9 +35,9 @@ module.exports = (createCommon, options) => {
     it('should not read not found, expect error', (done) => {
       const testDir = `/test-${hat()}`
 
-      ipfs.files.read(`${testDir}/404`, (err, buf) => {
+      ipfs.files.read(`${testDir}/404`, (err) => {
         expect(err).to.exist()
-        expect(buf).to.not.exist()
+        expect(err.message).to.contain('does not exist')
         done()
       })
     })


### PR DESCRIPTION
Js says 'file did not exist', go says 'file does not exist'.