### PR TITLE
fix: allow retries for DNS test due to dependence on external services

### DIFF
--- a/js/src/miscellaneous/dns.js
+++ b/js/src/miscellaneous/dns.js
@@ -32,6 +32,7 @@ module.exports = (createCommon, options) => {
 
     it('should resolve a DNS link', function (done) {
       this.timeout(20 * 1000)
+      this.retries(3)
 
       ipfs.dns('ipfs.io', (err, path) => {
         expect(err).to.not.exist()


### PR DESCRIPTION
Until we have a good way to mock out a DNS server in node and the browser this will hopefully decrease test failures when the external network or `https://ipfs.io/api/v0/dns` is slow or busy.