### PR TITLE
WIP: fix: ipns tests using go daemon

### DIFF
--- a/js/src/name/publish.js
+++ b/js/src/name/publish.js
@@ -39,7 +39,7 @@ module.exports = (createCommon, options) => {
     after((done) => common.teardown(done))
 
     it('should publish an IPNS record with the default params', function (done) {
-      this.timeout(50 * 1000)
+      this.timeout(120 * 1000)
 
       const value = fixture.cid
 
@@ -54,7 +54,7 @@ module.exports = (createCommon, options) => {
     })
 
     it('should publish correctly when the file was not added but resolve is disabled', function (done) {
-      this.timeout(50 * 1000)
+      this.timeout(120 * 1000)
 
       const value = 'QmPFVLPmp9zv5Z5KUqLhe2EivAGccQW2r7M7jhVJGLZoZU'
 
@@ -76,7 +76,7 @@ module.exports = (createCommon, options) => {
     })
 
     it('should publish with a key received as param, instead of using the key of the node', function (done) {
-      this.timeout(90 * 1000)
+      this.timeout(140 * 1000)
 
       const value = fixture.cid
       const options = {

--- a/js/src/name/resolve.js
+++ b/js/src/name/resolve.js
@@ -41,7 +41,7 @@ module.exports = (createCommon, options) => {
     after((done) => common.teardown(done))
 
     it('should resolve a record with the default params after a publish', function (done) {
-      this.timeout(50 * 1000)
+      this.timeout(120 * 1000)
 
       const value = fixture.cid
 
@@ -52,7 +52,7 @@ module.exports = (createCommon, options) => {
         ipfs.name.resolve(nodeId, (err, res) => {
           expect(err).to.not.exist()
           expect(res).to.exist()
-          expect(res.path).to.equal(`/ipfs/${value}`)
+          expect(res.path || res).to.equal(`/ipfs/${value}`) // TODO
 
           done()
         })
@@ -60,14 +60,12 @@ module.exports = (createCommon, options) => {
     })
 
     it('should not get the entry if its validity time expired', function (done) {
-      this.timeout(50 * 1000)
+      this.timeout(140 * 1000)
 
       const value = fixture.cid
       const publishOptions = {
-        resolve: true,
-        lifetime: '1ms',
-        ttl: '10s',
-        key: 'self'
+        resolve: false,
+        lifetime: '10ms'
       }
 
       ipfs.name.publish(value, publishOptions, (err, res) => {
@@ -83,12 +81,12 @@ module.exports = (createCommon, options) => {
 
             done()
           })
-        }, 1)
+        }, 10)
       })
     })
 
     it('should recursively resolve to an IPFS hash', function (done) {
-      this.timeout(100 * 1000)
+      this.timeout(150 * 1000)
 
       const value = fixture.cid
       const publishOptions = {
@@ -125,7 +123,7 @@ module.exports = (createCommon, options) => {
             ipfs.name.resolve(keyId, resolveOptions, (err, res) => {
               expect(err).to.not.exist()
               expect(res).to.exist()
-              expect(res.path).to.equal(`/ipfs/${value}`)
+              expect(res.path || res).to.equal(`/ipfs/${value}`) // TODO
 
               done()
             })


### PR DESCRIPTION
In the context of having the `ipns` tests running on [js-ipfs-api#841](https://github.com/ipfs/js-ipfs-api/pull/841)