### PR TITLE
fix: ipfs.io now should be resolved recursively

### DIFF
--- a/js/src/miscellaneous/dns.js
+++ b/js/src/miscellaneous/dns.js
@@ -34,7 +34,7 @@ module.exports = (createCommon, options) => {
       this.timeout(20 * 1000)
       this.retries(3)
 
-      ipfs.dns('ipfs.io', (err, path) => {
+      ipfs.dns('ipfs.io', {r: true}, (err, path) => {
         expect(err).to.not.exist()
         expect(path).to.exist()
         done()

--- a/js/src/miscellaneous/resolve.js
+++ b/js/src/miscellaneous/resolve.js
@@ -92,7 +92,7 @@ module.exports = (createCommon, options) => {
     it('should resolve an IPNS DNS link', function (done) {
       this.timeout(20 * 1000)
 
-      ipfs.resolve('/ipns/ipfs.io', {r: true},(err, path) => {
+      ipfs.resolve('/ipns/ipfs.io', {r: true}, (err, path) => {
         expect(err).to.not.exist()
         expect(isIpfs.ipfsPath(path)).to.be.true()
         done()

--- a/js/src/miscellaneous/resolve.js
+++ b/js/src/miscellaneous/resolve.js
@@ -92,7 +92,7 @@ module.exports = (createCommon, options) => {
     it('should resolve an IPNS DNS link', function (done) {
       this.timeout(20 * 1000)
 
-      ipfs.resolve('/ipns/ipfs.io', (err, path) => {
+      ipfs.resolve('/ipns/ipfs.io', {r: true},(err, path) => {
         expect(err).to.not.exist()
         expect(isIpfs.ipfsPath(path)).to.be.true()
         done()


### PR DESCRIPTION
Since `ipfs.io` is now switched to indirect name, it should be resolved recursively.