### PR TITLE
fix: dht find peer and providers

### DIFF
--- a/js/src/dht/findpeer.js
+++ b/js/src/dht/findpeer.js
@@ -48,7 +48,7 @@ module.exports = (createCommon, options) => {
 
     it('should fail to find other peer if peer does not exist', (done) => {
       nodeA.dht.findpeer('Qmd7qZS4T7xXtsNFdRoK1trfMs5zU94EpokQ9WFtxdPxsZ', (err, peer) => {
-        expect(err).to.not.exist()
+        expect(err).to.exist()
         expect(peer).to.not.exist()
         done()
       })

--- a/js/src/dht/findprovs.js
+++ b/js/src/dht/findprovs.js
@@ -60,7 +60,7 @@ module.exports = (createCommon, options) => {
         },
         (cidV0, cb) => nodeA.dht.findprovs(cidV0, cb),
         (provs, cb) => {
-          expect(provs.map((p) => p.toB58String()))
+          expect(provs.map((p) => p.id.toB58String()))
             .to.eql([nodeB.peerId.id])
           cb()
         }


### PR DESCRIPTION
Fixes for getting [Awesome Endeavour: DHT Part II](https://github.com/ipfs/js-ipfs/pull/856) on track.

- `findprovs`

The `findproviders` kad-dht function, which is provided by `js-libp2p` through `findprovs` function, receives a `PeerInfo` array in the resulting callback, as [js-libp2p-kad-dht/index.js#L432](https://github.com/libp2p/js-libp2p-kad-dht/blob/master/src/index.js#L432). Accordingly, we need to add `p.id`.

- `findpeer`

The `findPeer` kad-dht function, which is provided by `js-libp2p` through kad-dht `findpeer` function, receives an error, if the peer was not found, as [js-libp2p-kad-dht/index.js#L527](https://github.com/libp2p/js-libp2p-kad-dht/blob/master/src/index.js#L527). This way, it should receive an error.

