### PR TITLE
ipfs.files.add: Notes about ipfs.types.Buffer.

### DIFF
--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -192,7 +192,7 @@ let hash = results[0].hash; // "Qm...WW"
 Now [ipfs.io/ipfs/Qm...WW](https://ipfs.io/ipfs/QmNz1UBzpdd4HfZ3qir3aPiRdX5a93XwTuDNyXRc6PKhWW)
 returns the "ABC" string.
 
-The following code creates a directory object:
+The following allows you to add multiple files at once. Note that intermediate directories in file paths will be automatically created and returned in the response along with files:
 
 ```JavaScript
 const files = [

--- a/SPEC/FILES.md
+++ b/SPEC/FILES.md
@@ -181,17 +181,45 @@ If no `callback` is passed, a promise is returned.
 
 **Example:**
 
+In the browser, assuming `ipfs = new Ipfs(...)`:
+
+```js
+let content = ipfs.types.Buffer.from('ABC');
+let results = await ipfs.files.add(content);
+let hash = results[0].hash; // "Qm...WW"
+```
+
+Now [ipfs.io/ipfs/Qm...WW](https://ipfs.io/ipfs/QmNz1UBzpdd4HfZ3qir3aPiRdX5a93XwTuDNyXRc6PKhWW)
+returns the "ABC" string.
+
+The following code creates a directory object:
+
 ```JavaScript
 const files = [
   {
     path: '/tmp/myfile.txt',
-    content: (Buffer or Readable stream)
+    content:  ipfs.types.Buffer.from('ABC')
   }
 ]
 
-ipfs.files.add(files, function (err, files) {
-  // 'files' will be an array of objects containing paths and the multihashes of the files added
-})
+const results = await ipfs.files.add(files);
+```
+
+The `results` array:
+
+```json
+[
+  {
+    "path": "tmp",
+    "hash": "QmWXdjNC362aPDtwHPUE9o2VMqPeNeCQuTBTv1NsKtwypg",
+    "size": 67
+  },
+  {
+    "path": "/tmp/myfile.txt",
+    "hash": "QmNz1UBzpdd4HfZ3qir3aPiRdX5a93XwTuDNyXRc6PKhWW",
+    "size": 11
+  }
+]
 ```
 
 A great source of [examples][] can be found in the tests for this API.


### PR DESCRIPTION
I've spent an hour trying to figure out how to do `ipfs add` in the browser: docs describe the "Buffer" part really vaguely and don't mention that `ipfs.files.add` in fact creates a directory object unless used with a correctly created buffer. It works with an incorrectly created buffer, but creates a directory with auto-generated name:

```js
let data = new Uint8Array([0x41, 0x42, 0x43]);
let results = await ipfs.files.add(data);
```

Here `results` is

```json
[
  {
    "path": "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn",
    "hash": "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn",
    "size": 4
  }
]
```

Now open this hash in `ipfs.io` and try to figure out wtf that is and why size is 4. The `ipfs.types.Buffer` was the key.