### PR TITLE
chore: remove ipld formats re-export

### DIFF
--- a/js/src/types.js
+++ b/js/src/types.js
@@ -3,8 +3,6 @@
 
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const dagCBOR = require('ipld-dag-cbor')
-const dagPB = require('ipld-dag-pb')
 const multiaddr = require('multiaddr')
 const multibase = require('multibase')
 const multihash = require('multihashes')
@@ -44,9 +42,7 @@ module.exports = (createCommon, options) => {
         multiaddr: multiaddr,
         multibase: multibase,
         multihash: multihash,
-        CID: CID,
-        dagPB: dagPB,
-        dagCBOR: dagCBOR
+        CID: CID
       })
     })
   })


### PR DESCRIPTION
Prior to this change the `ipld-dag-cbor` and `ipld-dag-pb` modules
are re-exported so that can be accessed within the Browser bundle.
Those modules normally don't need to be used directly, they are
kind of implementation details of IPLD. Hence remove them.