### PR TITLE
Match new 'no link' error in files.cat

### DIFF
--- a/js/src/files/cat.js
+++ b/js/src/files/cat.js
@@ -136,6 +136,7 @@ module.exports = (createCommon, options) => {
           expect(err).to.exist()
           expect(err.message).to.oneOf([
             'No such file',
+            'no link by that name',
             'no link named "does-not-exist" under Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'])
         })
     })


### PR DESCRIPTION
There was a ton of refactoring in go-ipfs which caused a slightly different error to be exposed here