### PR TITLE
refactor: convert utils to use async/await

### DIFF
--- a/js/src/utils/mocha.js
+++ b/js/src/utils/mocha.js
@@ -3,8 +3,10 @@
 
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
+const chaiAsPromised = require('chai-as-promised')
 
 chai.use(dirtyChai)
+chai.use(chaiAsPromised)
 
 module.exports.expect = chai.expect
 

--- a/js/src/utils/swarm.js
+++ b/js/src/utils/swarm.js
@@ -1,20 +1,18 @@
 'use strict'
 
-const eachSeries = require('async/eachSeries')
+const pause = ms => new Promise((resolve, reject) => setTimeout(resolve, ms))
 
-function connect (fromNode, toAddrs, cb) {
+async function connect (fromNode, toAddrs, cb) {
   if (!Array.isArray(toAddrs)) {
     toAddrs = [toAddrs]
   }
 
   // FIXME ??? quick connections to different nodes sometimes cause no
   // connection and no error, hence serialize connections and pause between
-  eachSeries(toAddrs, (toAddr, cb) => {
-    fromNode.swarm.connect(toAddr, (err) => {
-      if (err) return cb(err)
-      setTimeout(cb, 300)
-    })
-  }, cb)
+  for (let i = 0; i < toAddrs.length; i++) {
+    await fromNode.swarm.connect(toAddrs[i])
+    await pause(300)
+  }
 }
 
 module.exports.connect = connect

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "homepage": "https://github.com/ipfs/interface-ipfs-core#readme",
   "dependencies": {
     "aegir": "^17.0.1",
-    "async": "^2.6.1",
     "big.js": "^5.2.2",
     "bl": "^2.1.2",
     "bs58": "^4.0.1",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cids": "~0.5.5",
     "concat-stream": "^1.6.2",
     "crypto": "^1.0.1",
@@ -46,6 +46,7 @@
     "ipld-dag-cbor": "~0.13.0",
     "ipld-dag-pb": "~0.14.11",
     "is-ipfs": "~0.4.7",
+    "is-plain-object": "^2.0.4",
     "libp2p-crypto": "~0.14.0",
     "multiaddr": "^5.0.0",
     "multibase": "~0.5.0",
@@ -54,8 +55,7 @@
     "peer-id": "~0.12.0",
     "peer-info": "~0.14.1",
     "pull-stream": "^3.6.9",
-    "pump": "^3.0.0",
-    "is-plain-object": "^2.0.4"
+    "pump": "^3.0.0"
   },
   "contributors": [
     "Alan Shaw <alan.shaw@protocol.ai>",


### PR DESCRIPTION
NOTE: the PRs for https://github.com/ipfs/js-ipfs/issues/1670 are being merged into the `feat/async-iterators` branch. Once they're all in we can merge them into master.

I plan to submit a PR for each subsystem to keep them quick and easy to review.

---

This PR simply converts the modules in `js/src/utils` to use async/await.

Also:

* Removes `async` - we're not going to need this anymore!
* Adds `chai-as-promised` for easier assertions with promises