### PR TITLE
chore: increase ping test timeouts

### DIFF
--- a/js/src/ping/ping-pull-stream.js
+++ b/js/src/ping/ping-pull-stream.js
@@ -14,14 +14,12 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.pingPullStream', function () {
-    this.timeout(40 * 1000)
+    this.timeout(60 * 1000)
 
     let ipfsA
     let ipfsB
 
     before(function (done) {
-      this.timeout(60 * 1000)
-
       common.setup((err, factory) => {
         if (err) return done(err)
 

--- a/js/src/ping/ping-readable-stream.js
+++ b/js/src/ping/ping-readable-stream.js
@@ -15,14 +15,12 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.pingReadableStream', function () {
-    this.timeout(30 * 1000)
+    this.timeout(60 * 1000)
 
     let ipfsA
     let ipfsB
 
     before(function (done) {
-      this.timeout(60 * 1000)
-
       common.setup((err, factory) => {
         if (err) return done(err)
 

--- a/js/src/ping/ping.js
+++ b/js/src/ping/ping.js
@@ -13,7 +13,7 @@ module.exports = (createCommon, options) => {
   const common = createCommon()
 
   describe('.ping', function () {
-    this.timeout(40 * 1000)
+    this.timeout(60 * 1000)
 
     let ipfsA
     let ipfsB

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "js/src/index.js",
   "scripts": {
     "test": "exit 0",
+    "test:node": "exit 0",
+    "test:browser": "exit 0",
+    "test:webworker": "exit 0",
     "lint": "aegir lint",
     "release": "aegir release -t node --no-docs --no-build --no-test",
     "release-minor": "aegir release -t node --type minor --no-docs --no-build --no-test",


### PR DESCRIPTION
These tests take ages locally and are even slower on the Jenkins Mac workers so this PR increases their timeouts to values verging on unreasonable.