### PR TITLE
Add peers with errors to swarm.peers definition

### DIFF
--- a/SPEC/SWARM.md
+++ b/SPEC/SWARM.md
@@ -102,6 +102,13 @@ Starting with `go-ipfs 0.4.5` these additional properties are provided
 - `muxer: String` - The type of stream muxer the peer is usng
 - `streams: []String` - Only if `verbose: true`, a list of currently open streams
 
+If an error occurs trying to create an individual `peerInfo` object, it will have the properties
+
+- `error: Error` - the error that occurred
+- `rawPeerInfo: Object` - the raw data for the peer
+
+and all other properties may be undefined.
+
 If no `callback` is passed, a promise is returned.
 
 **Example:**


### PR DESCRIPTION
js-ipfs-api can encounter individual peer info objects that have newer multiaddrs or, in theory, a new format for PeerId that it cannot parse. Allowing for individiual peerInfo validation errors allows us to return a response which has the right number of peers in, and peerId and multiaddr info for all the other peers that could be validated, along with a info about peers that failed to validate.

See: https://github.com/ipfs/js-ipfs-api/pull/887