### PR TITLE
fix: ipns over pubsub tests

### DIFF
--- a/js/src/name-pubsub/cancel.js
+++ b/js/src/name-pubsub/cancel.js
@@ -68,9 +68,9 @@ module.exports = (createCommon, options) => {
             expect(err).to.exist()
             auto({
               subs1: (cb) => ipfs.name.pubsub.subs(cb),
-              cancel: (cb) => ipfs.name.pubsub.cancel(ipnsPath, cb),
-              subs2: (cb) => ipfs.name.pubsub.subs(cb)
-            }, 1, (err, res) => {
+              cancel: ['subs1', (_, cb) => ipfs.name.pubsub.cancel(ipnsPath, cb)],
+              subs2: ['cancel', (_, cb) => ipfs.name.pubsub.subs(cb)]
+            }, (err, res) => {
               expect(err).to.not.exist()
               expect(res).to.exist()
               expect(res.subs1).to.be.an('array').that.does.include(ipnsPath)


### PR DESCRIPTION
If we have an IPNS record value in cache, we will not hit the resolver and consequently, we are not going to subscribe the topic, as it is only subscribed when we are looking for it.

According to the above, I removed the `publish` prior to the `resolve` in the tests, which lead to some changes in the structure of the test, as resolve will return an error, as a consequence of not having any record.