### PR TITLE
fix: allow only by object

### DIFF
--- a/js/src/utils/mocha.js
+++ b/js/src/utils/mocha.js
@@ -59,7 +59,14 @@ function getIt (config) {
     }
 
     if (Array.isArray(config.only)) {
-      if (config.only.includes(name)) return it.only(name, impl) // eslint-disable-line
+      const only = config.only
+        .map((o) => isObject(o) ? o : { name: o })
+        .find((o) => o.name === name)
+
+      if (only) {
+        if (only.reason) name = `${name} (${only.reason})`
+        return it.only(name, impl) // eslint-disable-line
+      }
     }
 
     it(name, impl)

--- a/js/src/utils/mocha.js
+++ b/js/src/utils/mocha.js
@@ -65,7 +65,7 @@ function getIt (config) {
 
       if (only) {
         if (only.reason) name = `${name} (${only.reason})`
-        return it.only(name, impl) // eslint-disable-line
+        return it.only(name, impl) // eslint-disable-line no-only-tests/no-only-tests
       }
     }
 
@@ -73,7 +73,7 @@ function getIt (config) {
   }
 
   _it.skip = it.skip
-  _it.only = it.only // eslint-disable-line
+  _it.only = it.only // eslint-disable-line no-only-tests/no-only-tests
 
   return _it
 }


### PR DESCRIPTION
The only option will now accept an object for onlying a specific test.

Previously you could only do this to only run a specific test:

```js
{
  only: ['should test a thing']
}
```

Now you can do this:

```js
{
  only: [{
    name: 'should test a thing',
    reason: 'because development' // optional!
  }]
}
```

License: MIT
Signed-off-by: Alan Shaw <alan.shaw@protocol.ai>